### PR TITLE
Server error handling

### DIFF
--- a/src/lib/components/form.svelte
+++ b/src/lib/components/form.svelte
@@ -34,13 +34,27 @@
 		form: superFrm,
 		schema
 	};
+
+	// Adding a variable to mantain tracking of server errors thrown in +page.server.ts action
+	let serverError: string | undefined = undefined;
 </script>
 
 {#if asChild}
+	<!-- Don't know how to manage here yet -->
 	<slot {config} formValues={$formStore} form={superFrm} {enhance} />
 {:else}
-	<form {...$$restProps} use:enhance>
-		<slot {config} formValues={$formStore} form={superFrm} {enhance} />
+	<form {...$$restProps} use:enhance={{
+		// We can add a custom onError handler to the enhance store
+		onError: ({result}) => {
+			serverError = result.error.message;
+		} 
+	}}>
+		<!-- We could add serverError directly on Form.Root -->
+		<slot {config} formValues={$formStore} form={superFrm} {enhance} {serverError} />
+
+		<!-- Or pass it as another slot -->
+		<slot name="serverError" {serverError} />	
+
 		{#if debug}
 			<SuperDebug data={$formStore} />
 		{/if}

--- a/src/routes/examples/server-error-tracking/+page.server.ts
+++ b/src/routes/examples/server-error-tracking/+page.server.ts
@@ -1,0 +1,24 @@
+import { error, fail, type Actions } from "@sveltejs/kit";
+import { superValidate } from "sveltekit-superforms/server";
+import { someFormSchema } from "../schemas.js";
+import type { PageServerLoad } from "./$types.js";
+
+export const load: PageServerLoad = async () => {
+	return {
+		form: superValidate(someFormSchema)
+	};
+};
+
+export const actions: Actions = {
+	default: async (event) => {
+		const form = await superValidate(event, someFormSchema);
+		if (!form.valid) return fail(400, { form });
+
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+		throw error(500, "Something went wrong");
+
+		// return {
+		// 	form
+		// };
+	}
+};

--- a/src/routes/examples/server-error-tracking/+page.svelte
+++ b/src/routes/examples/server-error-tracking/+page.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	import { Button } from "@/components/ui/button/index.js";
+	import { Form } from "@/lib/index.js";
+	import { someFormSchema } from "../schemas.js";
+	import type { PageData } from "./$types.js";
+
+	export let data: PageData;
+</script>
+
+<div class="flex flex-col h-full min-h-screen w-full items-center py-28">
+	<h1 class="text-3xl font-semibold tracking-tight pb-8">Account Settings</h1>
+	<!-- Same form as only-formsnap example -->
+	<Form.Root
+		schema={someFormSchema}
+		form={data.form}
+		debug={true}
+		let:config
+		let:serverError
+		method="POST"
+		class="container max-w-[750px] mx-auto flex flex-col gap-8"
+	>
+		<Form.Field {config} name="email">
+			<div class="grid gap-2">
+				<Form.Label>Email</Form.Label>
+				<Form.Input class="rounded bg-background border border-border h-9 text-foreground p-2" />
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.Field>
+		<Form.Field {config} name="username">
+			<div class="grid gap-2">
+				<Form.Label>Username</Form.Label>
+				<Form.Input class="rounded bg-background border border-border h-9 text-foreground p-2" />
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.Field>
+		<Form.Field {config} name="bio">
+			<div class="grid gap-2">
+				<Form.Label>Bio</Form.Label>
+				<Form.Textarea
+					rows={4}
+					class="resize-none rounded bg-background border border-border text-foreground p-2"
+				/>
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.Field>
+		<Form.Field {config} name="website">
+			<div class="grid gap-2">
+				<Form.Label>Website</Form.Label>
+				<Form.Input class="rounded bg-background border border-border h-9 text-foreground p-2" />
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.Field>
+		<Form.Field {config} name="notifications">
+			<div class="grid gap-2">
+				<Form.Label>Notifications</Form.Label>
+				<Form.Select class="rounded bg-background border border-border h-9 text-foreground p-2">
+					<option value="all">All</option>
+					<option value="mentions">Mentions</option>
+					<option value="none">None</option>
+				</Form.Select>
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.Field>
+		<Form.Field {config} name="language">
+			<div class="grid gap-2">
+				<Form.Label>Language</Form.Label>
+				<Form.Select class="rounded bg-background border border-border h-9 text-foreground p-2">
+					<option value="en">English</option>
+					<option value="es">Spanish</option>
+					<option value="fr">French</option>
+				</Form.Select>
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.Field>
+		<Form.Field {config} name="usage">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-4">
+					<Form.Checkbox />
+					<Form.Label>Send crash reports & statistics</Form.Label>
+				</div>
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.Field>
+		<Form.Field {config} name="theme">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-4">
+					<Form.Radio value="light" />
+					<Form.Label>Light</Form.Label>
+				</div>
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.Field>
+		<Form.Field {config} name="theme">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-4">
+					<Form.Radio value="dark" />
+					<Form.Label>Dark</Form.Label>
+				</div>
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.Field>
+
+		<!-- Here we manage the serverError -->
+
+		<!-- First way: with custom slot -->
+		<div slot="serverError" let:serverError>
+			{#if serverError}
+				<p class="text-destructive">{serverError}</p>
+			{/if}
+		</div>
+
+		<!-- Second way: with let variable - This seems more clean to me -->
+		{#if serverError}
+			<p class="text-destructive">{serverError}</p>
+		{/if}
+
+		<Button type="submit">Submit</Button>
+	</Form.Root>
+</div>


### PR DESCRIPTION
Hi @huntabyte! 
I feel very happy with this library, I have to deal with management systems containing dozens of forms for work and I've been looking for a definitive solution since the form actions came out. I hope this will be the way!

A feature that I find myself having to add to all forms is to handle a possible server-side error (eg. `throw errror('Internal Server Error')` in an action).
This can be done by customizing the `onError` event of _superForm_, saving any error in a variable and showing an alert containing the error. Needing to be done on all forms at the moment I built a _superform_ wrapper that handled this error, using help from @ciscoheat -> https://github.com/ciscoheat/sveltekit-superforms/issues/246#issuecomment-1670529970.

So I would like to send you a proposal to integrate this server side error handling directly into the library. In `shadcn-svelte` it might be useful to handle it directly with an `Alert`.

Thank you!
