### PR TITLE
Handle delayed

### DIFF
--- a/src/lib/components/form-button.svelte
+++ b/src/lib/components/form-button.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { ButtonProps } from "../types.js";
+
+	import type { AnyZodObject } from "zod";
+
+	type T = $$Generic<AnyZodObject>;
+
+	type $$Props = ButtonProps<T>;
+
+	export let config: $$Props["config"];
+
+	const { delayed } = config.form;
+
+</script>
+<!-- Could be named form-submit instead of form-button ? -->
+<slot
+    delayed={$delayed}
+/>

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,12 +1,25 @@
+import Button from "./form-button.svelte";
+import Checkbox from "./form-checkbox.svelte";
 import Description from "./form-description.svelte";
 import Field from "./form-field.svelte";
+import Input from "./form-input.svelte";
 import Label from "./form-label.svelte";
+import Radio from "./form-radio.svelte";
+import Select from "./form-select.svelte";
+import Textarea from "./form-textarea.svelte";
 import Validation from "./form-validation.svelte";
 import Root from "./form.svelte";
-import Input from "./form-input.svelte";
-import Textarea from "./form-textarea.svelte";
-import Select from "./form-select.svelte";
-import Checkbox from "./form-checkbox.svelte";
-import Radio from "./form-radio.svelte";
 
-export { Root, Field, Label, Description, Validation, Input, Textarea, Select, Checkbox, Radio };
+export {
+	Button,
+	Checkbox,
+	Description,
+	Field,
+	Input,
+	Label,
+	Radio,
+	Root,
+	Select,
+	Textarea,
+	Validation
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,6 +32,11 @@ export type FieldProps<T extends AnyZodObject = AnyZodObject, Path = FormFieldNa
 	name: Path;
 };
 
+// Or SubmitProps?
+export type ButtonProps<T extends AnyZodObject = AnyZodObject> = {
+	config: Form<T>;
+};
+
 export type InputProps = HTMLInputAttributes;
 export type CheckboxProps = HTMLInputAttributes;
 

--- a/src/routes/examples/only-formsnap/+page.server.ts
+++ b/src/routes/examples/only-formsnap/+page.server.ts
@@ -13,7 +13,7 @@ export const actions: Actions = {
 	default: async (event) => {
 		const form = await superValidate(event, someFormSchema);
 		if (!form.valid) return fail(400, { form });
-
+		await new Promise((resolve) => setTimeout(resolve, 1000));
 		return {
 			form
 		};

--- a/src/routes/examples/only-formsnap/+page.svelte
+++ b/src/routes/examples/only-formsnap/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { Form } from "@/lib/index.js";
-	import type { PageData } from "./$types.js";
-	import { someFormSchema } from "../schemas.js";
 	import { Button } from "@/components/ui/button/index.js";
+	import { Form } from "@/lib/index.js";
+	import { someFormSchema } from "../schemas.js";
+	import type { PageData } from "./$types.js";
 
 	export let data: PageData;
 </script>
@@ -97,6 +97,14 @@
 				<Form.Validation class="text-destructive" />
 			</div>
 		</Form.Field>
-		<Button type="submit">Submit</Button>
+		<Form.Button {config} let:delayed>
+			<Button type="submit" disabled={delayed}>
+				{#if delayed}
+					...
+				{/if}
+				Submit
+			</Button>
+		</Form.Button>
+		
 	</Form.Root>
 </div>


### PR DESCRIPTION
Also a feature I always add is the loading spinner in the submit button, or in general I want to know when the form is in a submitting state. Superform give us the delayed store for managing this kind of situations.

Through the config that form exposes we can access the superform delayed store, do you think it could be useful to do it directly from formsnap, giving the user a component that subscribe to the store?

I send you a proposal! 
I created a new component exposes by the library called form-button (it could be named form-submit or anything else).

Thank you