### PR TITLE
Add a `getFormField` helper function

### DIFF
--- a/.changeset/fresh-parents-bake.md
+++ b/.changeset/fresh-parents-bake.md
@@ -1,0 +1,39 @@
+---
+"formsnap": patch
+---
+
+#### Add a `getFormField` helper function
+
+The `getFormField` helper function must be called upon component initialization and provides some useful stores, actions, etc. when composing your own forms.
+For example, if I wanted to create a reusable `Form.Label` with conditional styles applied to it depending on the error state of the field, I could do something like this:
+
+```svelte
+<!-- CustomLabel.svelte -->
+<script lang="ts">
+	import { Form, getFormField } from 'formsnap';	
+	const { errors } = getFormField()
+</script>
+
+<Form.Label class={$errors ? "text-red-500" : "text-gray-800"}>
+	<slot />
+</Form.Label>
+```
+
+
+It returns the following type:
+```ts
+export type FormFieldContext = {
+	name: string;
+	ids: {
+		input: string;
+		description: string;
+		validation: string;
+	};
+	errors: Writable<string[] | undefined>;
+	value: Writable<unknown>;
+	hasDescription: Writable<boolean>;
+	hasValidation: Writable<boolean>;
+	attrStore: AttrStore;
+	actions: ActionsObject;
+};
+```

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,5 @@
 // Reexport your entry components here
+import { getCtx } from "./internal/form-field.js";
 export * as Form from "./components/index.js";
 export * from "./types.js";
+export { getCtx as getFormField };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,10 @@
 // Reexport your entry components here
-import { getCtx } from "./internal/form-field.js";
+import {
+	getCtx,
+	type ActionsObject,
+	type FormFieldContext,
+	type AttrStore
+} from "./internal/index.js";
 export * as Form from "./components/index.js";
 export * from "./types.js";
-export { getCtx as getFormField };
+export { getCtx as getFormField, ActionsObject, FormFieldContext, AttrStore };


### PR DESCRIPTION
This PR exports a `getFormField` helper function which must be called upon component initialization and provides some useful stores, actions, etc. when composing your own forms.

For example, if you want to create your own custom component wrappers around the provided components, `getFormField` can provide you with useful context.

For example, if I wanted to create a reusable `Form.Label` with conditional styles applied to it depending on the error state of the field, I could do something like this:

```svelte
<!-- CustomLabel.svelte -->
<script lang="ts">
	import { Form, getFormField } from 'formsnap';	
	const { errors } = getFormField()
</script>

<Form.Label class={$errors ? "text-red-500" : "text-gray-800"}>
	<slot />
</Form.Label>
```


It returns the following type:
```ts
export type FormFieldContext = {
	name: string;
	ids: {
		input: string;
		description: string;
		validation: string;
	};
	errors: Writable<string[] | undefined>;
	value: Writable<unknown>;
	hasDescription: Writable<boolean>;
	hasValidation: Writable<boolean>;
	attrStore: AttrStore;
	actions: ActionsObject;
};
```