### PR TITLE
add additional helpers to getFormField

### DIFF
--- a/.changeset/blue-meals-watch.md
+++ b/.changeset/blue-meals-watch.md
@@ -1,0 +1,5 @@
+---
+"formsnap": patch
+---
+
+Add the `handlers` object containing the event handler helpers as well as the `setValue` helper function to the `getFormField` return object.

--- a/src/lib/internal/form-field.ts
+++ b/src/lib/internal/form-field.ts
@@ -7,7 +7,9 @@ import type {
 	Form,
 	FormFieldContext,
 	FormStores,
-	GetFieldAttrsProps
+	GetFieldAttrsProps,
+	Handlers,
+	SetValue
 } from "./types.js";
 import { formFieldProxy } from "sveltekit-superforms/client";
 import { getContext, setContext } from "svelte";
@@ -73,6 +75,15 @@ export function createFormField<
 		checkbox: createCheckboxAction({ id: ids.input, value, name, attrs: attrStore })
 	};
 
+	const setValue = (v: unknown) => {
+		//@ts-expect-error - do we leave this as is, or do we want to force the type to match the schema?
+		// Pros: we don't have to deal with type narrowing inside the `setValue` function and we're runtime validating the type with zod anyways.
+		// Cons: we're not forcing the type to match the schema so more issues could occur.
+		value.set(v);
+	};
+
+	const handlers = createHandlers(setValue);
+
 	const context: FormFieldContext = {
 		ids,
 		name,
@@ -81,7 +92,9 @@ export function createFormField<
 		hasValidation,
 		hasDescription,
 		attrStore,
-		actions
+		actions,
+		setValue,
+		handlers
 	};
 
 	setContext(FORM_FIELD_CONTEXT, context);
@@ -117,7 +130,7 @@ export function createFormField<
 	};
 }
 
-export function createHandlers(setValue: (v: unknown) => void) {
+export function createHandlers(setValue: SetValue): Handlers {
 	return {
 		input: (e: Event) => {
 			const target = e.target;

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -38,6 +38,8 @@ export type FormFieldContext = {
 	hasValidation: Writable<boolean>;
 	attrStore: AttrStore;
 	actions: ActionsObject;
+	handlers: Handlers;
+	setValue: SetValue;
 };
 
 export type AttrStore = Writable<Record<string, unknown>>;
@@ -87,4 +89,21 @@ export type GetFieldAttrsProps<T> = {
 	constraints: Record<string, unknown> | undefined;
 	hasValidation: boolean;
 	hasDescription: boolean;
+};
+
+/**
+ * Sets the value of a field store to the given value.
+ */
+export type SetValue = (value: unknown) => void;
+
+/**
+ * An object of helper functions for setting the value of a field store
+ * using `on:input` and `on:change` for native form elements and their
+ * events.
+ */
+export type Handlers = {
+	input: (e: Event) => void;
+	checkbox: (e: Event) => void;
+	radio: (e: Event) => void;
+	select: (e: Event) => void;
 };


### PR DESCRIPTION
Adds the `handlers` object containing the event handler helpers as well as the `setValue` helper function to the `getFormField` return object.