### PR TITLE
Add `tag` prop to `Validation` & `Description`

### DIFF
--- a/.changeset/sour-dots-ring.md
+++ b/.changeset/sour-dots-ring.md
@@ -1,0 +1,5 @@
+---
+"formsnap": patch
+---
+
+Add `tag` prop to `Validation` & `Description`

--- a/src/lib/components/form-description.svelte
+++ b/src/lib/components/form-description.svelte
@@ -4,6 +4,8 @@
 
 	type $$Props = DescriptionProps;
 
+	export let tag = "p";
+
 	const { ids, hasDescription } = getCtx();
 
 	const action = createDescriptionAction({
@@ -12,6 +14,6 @@
 	});
 </script>
 
-<span use:action {...$$restProps}>
+<svelte:element this={tag} use:action {...$$restProps}>
 	<slot />
-</span>
+</svelte:element>

--- a/src/lib/components/form-validation.svelte
+++ b/src/lib/components/form-validation.svelte
@@ -4,6 +4,8 @@
 
 	type $$Props = ValidationProps;
 
+	export let tag = "p"
+
 	const { ids, errors, hasValidation } = getCtx();
 
 	const action = createValidationAction({
@@ -15,8 +17,8 @@
 	});
 </script>
 
-<span use:action {...$$restProps}>
+<svelte:element this={tag} use:action {...$$restProps}>
 	{#if $errors}
 		{$errors}
 	{/if}
-</span>
+</svelte:element>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,10 +35,23 @@ export type FieldProps<T extends AnyZodObject = AnyZodObject, Path = FormFieldNa
 export type InputProps = HTMLInputAttributes;
 export type CheckboxProps = HTMLInputAttributes;
 
-type HTMLSpanAttributes = HTMLAttributes<HTMLSpanElement>;
+export type DescriptionProps = {
+	/**
+	 * The tag to use for the description element.
+	 *
+	 * @default "p"
+	 */
+	tag?: "string";
+} & HTMLAttributes<HTMLElement>;
 
-export type DescriptionProps = HTMLSpanAttributes;
-export type ValidationProps = HTMLSpanAttributes;
+export type ValidationProps = {
+	/**
+	 * The tag to use for the validation message element.
+	 *
+	 * @default "p"
+	 */
+	tag?: "string";
+} & HTMLAttributes<HTMLElement>;
 
 export type RadioProps = HTMLInputAttributes;
 export type SelectProps = HTMLSelectAttributes;


### PR DESCRIPTION
This PR introduces the ability to customize the underlying HTML element/tag used for the `Description` and `Validation` components. You can pass a `tag` prop to change which element is rendered.

Both elements default to `<p/>` tags. 

```svelte
<Form.Message tag="span" />
<Form.Description tag="div" />
```