### PR TITLE
Fix: Value typing

### DIFF
--- a/.changeset/rotten-rocks-fly.md
+++ b/.changeset/rotten-rocks-fly.md
@@ -1,0 +1,5 @@
+---
+"formsnap": patch
+---
+
+Fix: Value typing

--- a/src/lib/components/form-field.svelte
+++ b/src/lib/components/form-field.svelte
@@ -1,30 +1,28 @@
 <script lang="ts">
-	import type { FieldProps } from "../types.js";
-	import { createFormField, type FormFieldName, createHandlers } from "@/lib/internal/index.js";
+	import { createFormField, type Form, type FormFieldName } from "@/lib/internal/index.js";
 	import type { AnyZodObject } from "zod";
 
 	type T = $$Generic<AnyZodObject>;
 	type Path = $$Generic<FormFieldName<T>>;
 
-	type $$Props = FieldProps<T, Path>;
+	export let config: Form<T>;
+	export let name: Path;
 
-	export let config: $$Props["config"];
-	export let name: $$Props["name"];
-
-	const { superFormStores, getFieldAttrs, actions, attrStore, hasValidation, hasDescription, ids } =
-		createFormField<T, Path>(config, name);
+	const {
+		superFormStores,
+		getFieldAttrs,
+		actions,
+		attrStore,
+		hasValidation,
+		hasDescription,
+		handlers,
+		setValue,
+		ids
+	} = createFormField<T, Path>(config, name);
 
 	const { value, errors, constraints } = superFormStores;
 
-	const setValue = (v: unknown) => {
-		//@ts-expect-error - do we leave this as is, or do we want to force the type to match
-		// the schema?
-		// Pros: we don't have to deal with type coercin inside the update function and since we're runtime validating with zod anyways, do we really lose anything?
-		value.set(v);
-	};
-	const handlers = createHandlers(setValue);
-
-	$: inputAttrs = getFieldAttrs<typeof $value>({
+	$: inputAttrs = getFieldAttrs({
 		val: $value,
 		errors: $errors,
 		constraints: $constraints,

--- a/src/lib/internal/form-field.ts
+++ b/src/lib/internal/form-field.ts
@@ -42,6 +42,8 @@ type CreateFormFieldReturn<
 	attrStore: AttrStore;
 	hasValidation: Writable<boolean>;
 	hasDescription: Writable<boolean>;
+	handlers: Handlers;
+	setValue: SetValue;
 };
 
 export function createFormField<
@@ -126,7 +128,9 @@ export function createFormField<
 		ids,
 		attrStore,
 		hasDescription,
-		hasValidation
+		hasValidation,
+		handlers,
+		setValue
 	};
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,5 +57,3 @@ export type RadioProps = HTMLInputAttributes;
 export type SelectProps = HTMLSelectAttributes;
 export type TextareaProps = HTMLTextareaAttributes;
 export type LabelProps = HTMLLabelAttributes;
-export * from "./internal/form-field.js";
-export * from "./internal/types.js";


### PR DESCRIPTION
Generics are weird in Svelte, this reverts some previous type abstractions that cause the type to disconnect when using the package.