### PR TITLE
Add default `method="POST"` to form

### DIFF
--- a/.changeset/sweet-toys-cover.md
+++ b/.changeset/sweet-toys-cover.md
@@ -1,0 +1,5 @@
+---
+"formsnap": patch
+---
+
+- Add `method="POST"` by default to `<Form.Root />`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ export const load: PageServerLoad = async () => {
 	schema={settingsFormSchema}
 	form={data.form}
 	let:config
-	method="POST"
 	action="?/someAction"
 >
 	<Form.Field {config} name="email">

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -141,7 +141,7 @@ All is not lost though, as the whole idea behind Formsnap is to make this proces
 	export let data: PageData;
 </script>
 
-<Form.Root method="POST" form={data.form} schema={signupFormSchema} let:config>
+<Form.Root form={data.form} schema={signupFormSchema} let:config>
 	<Form.Field {config} name="name">
 		<Form.Label>Name</Form.Label>
 		<Form.Input />

--- a/content/quick-start.md
+++ b/content/quick-start.md
@@ -69,13 +69,7 @@ Now that we have our form in the `PageData` object, we can use it, along with th
 	export let data: PageData;
 </script>
 
-<Form.Root
-	form={data.form}
-	schema={settingsSchema}
-	let:config
-	debug={true}
-	method="POST"
->
+<Form.Root form={data.form} schema={settingsSchema} let:config debug={true}>
 	<!-- ... -->
 </Form.Root>
 ```
@@ -100,13 +94,7 @@ You can think of form fields as the building blocks of your form. Each input wil
 	export let data: PageData;
 </script>
 
-<Form.Root
-	form={data.form}
-	schema={settingsSchema}
-	let:config
-	method="POST"
-	debug={true}
->
+<Form.Root form={data.form} schema={settingsSchema} let:config debug={true}>
 	<Form.Field {config} name="email">
 		<!-- ... -->
 	</Form.Field>
@@ -125,13 +113,7 @@ Now that we have our field and the context has been setup under the hood, we can
 	export let data: PageData;
 </script>
 
-<Form.Root
-	form={data.form}
-	schema={settingsSchema}
-	let:config
-	method="POST"
-	debug={true}
->
+<Form.Root form={data.form} schema={settingsSchema} let:config debug={true}>
 	<Form.Field {config} name="email">
 		<Form.Label>Email</Form.Label>
 		<Form.Input />
@@ -159,13 +141,7 @@ And that's really all it takes to setup a form field. Let's continue on with the
 	export let data: PageData;
 </script>
 
-<Form.Root
-	form={data.form}
-	schema={settingsSchema}
-	let:config
-	method="POST"
-	debug={true}
->
+<Form.Root form={data.form} schema={settingsSchema} let:config debug={true}>
 	<Form.Field {config} name="email">
 		<Form.Label>Email</Form.Label>
 		<Form.Input />

--- a/src/lib/components/form.svelte
+++ b/src/lib/components/form.svelte
@@ -86,7 +86,7 @@
 		message={$message}
 	/>
 {:else}
-	<form {...$$restProps} use:enhance>
+	<form method="POST" {...$$restProps} use:enhance>
 		<slot
 			{config}
 			{formStore}

--- a/src/routes/examples/custom-and-formsnap/+page.svelte
+++ b/src/routes/examples/custom-and-formsnap/+page.svelte
@@ -24,7 +24,6 @@
 		form={data.form}
 		debug={true}
 		let:config
-		method="POST"
 		class="container max-w-[750px] mx-auto flex flex-col gap-8"
 	>
 		<Form.Field {config} name="email" let:handlers let:attrs>

--- a/src/routes/examples/only-formsnap/+page.svelte
+++ b/src/routes/examples/only-formsnap/+page.svelte
@@ -14,7 +14,6 @@
 		form={data.form}
 		debug={true}
 		let:config
-		method="POST"
 		class="container max-w-[750px] mx-auto flex flex-col gap-8"
 	>
 		<Form.Field {config} name="email">


### PR DESCRIPTION
You can override this behavior by passing in a `method` prop to the `<Form.Root />` 