### PR TITLE
Make validators accept ZodEffects to handle refined schemas

### DIFF
--- a/.changeset/support-refined-schema.md
+++ b/.changeset/support-refined-schema.md
@@ -1,0 +1,4 @@
+---
+"formsnap": patch
+---
+Fix handling of refined zod schemas so as not to throw false type errors.

--- a/src/lib/internal/super-form-patch.ts
+++ b/src/lib/internal/super-form-patch.ts
@@ -261,7 +261,10 @@ export type SuperFormOptions<T extends ZodValidation<AnyZodObject>, M> = Partial
 		  }) => MaybePromise<unknown | void>);
 	dataType: "form" | "json";
 	jsonChunkSize: number;
-	validators: SuperValidators<T>;
+	validators:
+		| false
+		| SuperValidators<UnwrapEffects<T>>
+		| ZodValidation<UnwrapEffects<T>>;
 	validationMethod: "auto" | "oninput" | "onblur" | "submit-only";
 	defaultValidator: "keep" | "clear";
 	customValidity: boolean;

--- a/src/routes/examples/schemas.ts
+++ b/src/routes/examples/schemas.ts
@@ -40,5 +40,3 @@ export const simpleFormSchema = z.object({
 			message: "You need to accept the terms and conditions"
 		})
 });
-
-export type SomeFormSchema = typeof someFormSchema;


### PR DESCRIPTION
I just copied [the current definition of validators](https://github.com/ciscoheat/sveltekit-superforms/blob/d0744b8a43df7757398065a9a86ea4753a4c0a6c/src/lib/client/index.ts#L116) from [sveltekit-superform ](https://github.com/ciscoheat/sveltekit-superforms)

Fixes #45