### PR TITLE
Add support for array / multi-select fields

### DIFF
--- a/src/lib/components/form-field-multi.svelte
+++ b/src/lib/components/form-field-multi.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-	import { createFormField } from "@/lib/internal/index.js";
-	import type { Form, FormFieldName, FormValidation } from "@/lib/internal/index.js";
-	import type { AnyZodObject } from "zod";
+	import { createFormFieldMulti } from "@/lib/internal/index.js";
+	import type { Form, FormValidation } from "@/lib/internal/index.js";
+	import type { AnyZodObject, z } from "zod";
 
 	type T = $$Generic<AnyZodObject | FormValidation>;
-	type Path = $$Generic<FormFieldName<T>>;
+	type Options = $$Generic<keyof z.infer<T>[][number]>;
 
 	export let config: Form<T>;
-	export let name: Path;
+	export let name: Options;
 
 	const {
 		superFormStores,
@@ -19,7 +19,7 @@
 		handlers,
 		setValue,
 		ids
-	} = createFormField<T, Path>(config, name);
+	} = createFormFieldMulti<T, Options>(config, name);
 
 	const { value, errors, constraints } = superFormStores;
 

--- a/src/lib/components/form-validation.svelte
+++ b/src/lib/components/form-validation.svelte
@@ -9,6 +9,8 @@
 		"data-fs-validation": "",
 		"data-fs-error": $errors ? "" : undefined
 	};
+
+	console.log($errors);
 </script>
 
 <svelte:element this={tag} use:actions.validation {...attrs} {...$$restProps}>

--- a/src/lib/components/form.svelte
+++ b/src/lib/components/form.svelte
@@ -67,7 +67,8 @@
 
 	const config: Form<T> = {
 		form: superFrm,
-		schema
+		schema,
+		formStore
 	};
 	const attrs = {
 		"data-fs-form": "",

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -8,5 +8,18 @@ import Textarea from "./form-textarea.svelte";
 import Select from "./form-select.svelte";
 import Checkbox from "./form-checkbox.svelte";
 import Radio from "./form-radio.svelte";
+import FieldMulti from "./form-field-multi.svelte";
 
-export { Root, Field, Label, Description, Validation, Input, Textarea, Select, Checkbox, Radio };
+export {
+	Root,
+	Field,
+	FieldMulti,
+	Label,
+	Description,
+	Validation,
+	Input,
+	Textarea,
+	Select,
+	Checkbox,
+	Radio
+};

--- a/src/lib/internal/form-field/create-field.ts
+++ b/src/lib/internal/form-field/create-field.ts
@@ -1,8 +1,8 @@
 import type { FormPathLeaves, UnwrapEffects, ZodValidation } from "sveltekit-superforms";
 import type { AnyZodObject, z } from "zod";
-import { formFieldProxy } from "sveltekit-superforms/client";
+import { fieldProxy, formFieldProxy } from "sveltekit-superforms/client";
 import { setContext } from "svelte";
-import { writable } from "svelte/store";
+import { writable, type Writable } from "svelte/store";
 import { createFieldActions, createFieldHandlers, createIds } from "@/lib/internal/index.js";
 import type { Form, GetFieldAttrsProps } from "@/lib/internal/index.js";
 import type { CreateFormFieldReturn, FieldAttrStore, FieldContext } from "./types.js";
@@ -42,6 +42,99 @@ export function createFormField<
 	const context: FieldContext = {
 		ids,
 		name,
+		errors,
+		value,
+		hasValidation,
+		hasDescription,
+		attrStore,
+		actions,
+		setValue,
+		handlers
+	};
+
+	setContext(FORM_FIELD_CONTEXT, context);
+
+	function getFieldAttrs<T>(props: GetFieldAttrsProps<T>) {
+		const { val, errors, constraints, hasValidation, hasDescription } = props;
+		const describedBy = errors
+			? `${hasValidation ? ids.validation : ""} ${hasDescription ? ids.description : ""}`
+			: ids.description
+			? ids.description
+			: undefined;
+
+		return {
+			"aria-invalid": errors ? true : undefined,
+			"aria-describedby": describedBy,
+			"aria-required": !!constraints?.required,
+			"data-invalid": errors ? true : undefined,
+			"data-valid": errors ? undefined : true,
+			name,
+			id: ids.input,
+			value: val
+		} as const;
+	}
+
+	return {
+		superFormStores,
+		getFieldAttrs,
+		actions,
+		ids,
+		attrStore,
+		hasDescription,
+		hasValidation,
+		handlers,
+		setValue
+	};
+}
+
+export function createFormFieldMulti<
+	T extends ZodValidation<AnyZodObject>,
+	Path extends (keyof z.infer<T>)[][number]
+>(form: Form<T>, name: Path) {
+	const { form: formStore, errors: formErrors, constraints: formConstraints } = form.form;
+
+	// @ts-expect-error - temp ignore until I can figure out how to type this elegantly
+	const value = fieldProxy(formStore, name);
+	// @ts-expect-error - temp ignore until I can figure out how to type this elegantly
+	const errors: Writable<string[] | undefined> = fieldProxy(formErrors, `${name}._errors`);
+	//@ts-expect-error - temp ignore until I can figure out how to type this elegantly
+	const constraints = fieldProxy(formConstraints, `${name}._constraints`);
+
+	const superFormStores = {
+		value,
+		errors,
+		constraints,
+		path: name
+	};
+
+	const attrStore: FieldAttrStore = writable({});
+	const hasValidation = writable(false);
+	const hasDescription = writable(false);
+
+	// const { errors, value } = superFormStores;
+	const ids = createIds();
+
+	const actions = createFieldActions({
+		ids,
+		attrs: attrStore,
+		hasValidation,
+		hasDescription,
+		value,
+		name: name as string
+	});
+
+	const setValue = (v: unknown) => {
+		//@ts-expect-error - do we leave this as is, or do we want to force the type to match the schema?
+		// Pros: we don't have to deal with type narrowing inside the `setValue` function, and we're runtime validating the type with zod anyways.
+		// Cons: we're not forcing the type to match the schema so more issues could occur.
+		value.set(v);
+	};
+
+	const handlers = createFieldHandlers(setValue);
+
+	const context: FieldContext = {
+		ids,
+		name: name as string,
 		errors,
 		value,
 		hasValidation,

--- a/src/lib/internal/form-field/create-field.ts
+++ b/src/lib/internal/form-field/create-field.ts
@@ -37,7 +37,7 @@ export function createFormField<
 		value.set(v);
 	};
 
-	const handlers = createFieldHandlers(setValue);
+	const handlers = createFieldHandlers(setValue, value);
 
 	const context: FieldContext = {
 		ids,
@@ -130,7 +130,7 @@ export function createFormFieldMulti<
 		value.set(v);
 	};
 
-	const handlers = createFieldHandlers(setValue);
+	const handlers = createFieldHandlers(setValue, value);
 
 	const context: FieldContext = {
 		ids,

--- a/src/lib/internal/form-field/create-handlers.ts
+++ b/src/lib/internal/form-field/create-handlers.ts
@@ -4,11 +4,15 @@ import {
 	isHTMLTextareaElement
 } from "@/lib/internal/index.js";
 import type { FieldHandlers, FieldValueSetter } from "./types.js";
+import type { Writable } from "svelte/store";
 
 /**
  * Creates an object of event handler functions for native form elements.
  */
-export function createFieldHandlers(setValue: FieldValueSetter): FieldHandlers {
+export function createFieldHandlers(
+	setValue: FieldValueSetter,
+	valueStore: Writable<unknown>
+): FieldHandlers {
 	return {
 		input: (e: Event) => {
 			const target = e.target;
@@ -41,6 +45,27 @@ export function createFieldHandlers(setValue: FieldValueSetter): FieldHandlers {
 				}
 			}
 			setValue(value);
+		},
+		multiCheck: (e: Event) => {
+			const target = e.target;
+			if (!isHTMLInputElement(target)) return;
+
+			if (target.checked) {
+				valueStore.update((v) => {
+					if (Array.isArray(v)) {
+						v.push(target.value);
+						return v;
+					}
+					return v;
+				});
+			} else {
+				valueStore.update((v) => {
+					if (Array.isArray(v)) {
+						return v.filter((val) => val !== target.value);
+					}
+					return v;
+				});
+			}
 		}
 	};
 }

--- a/src/lib/internal/form-field/create-handlers.ts
+++ b/src/lib/internal/form-field/create-handlers.ts
@@ -29,6 +29,18 @@ export function createFieldHandlers(setValue: FieldValueSetter): FieldHandlers {
 			const target = e.target;
 			if (!isHTMLSelectElement(target)) return;
 			setValue(target.value);
+		},
+		multiSelect: (e: Event) => {
+			const target = e.target;
+			if (!isHTMLSelectElement(target)) return;
+			const options = target.options;
+			const value = [];
+			for (let i = 0; i < options.length; i++) {
+				if (options[i].selected) {
+					value.push(options[i].value);
+				}
+			}
+			setValue(value);
 		}
 	};
 }

--- a/src/lib/internal/form-field/types.ts
+++ b/src/lib/internal/form-field/types.ts
@@ -173,6 +173,7 @@ export type FieldHandlers = {
 	checkbox: (e: Event) => void;
 	radio: (e: Event) => void;
 	select: (e: Event) => void;
+	multiSelect: (e: Event) => void;
 };
 
 export type CreateFieldActionsProps = {

--- a/src/lib/internal/form-field/types.ts
+++ b/src/lib/internal/form-field/types.ts
@@ -109,6 +109,14 @@ export type FieldActions = {
 	checkbox: Action<HTMLInputElement>;
 
 	/**
+	 * An action for setting the attributes and event handlers for a multi-select
+	 * checkbox component.
+	 *
+	 * @usage `<input type="checkbox" use:actions.multiCheckbox />`
+	 */
+	multiCheckbox: Action<HTMLInputElement>;
+
+	/**
 	 * An action for setting up the attributes & state for a description component.
 	 *
 	 * @usage `<span use:actions.description>...</span>`
@@ -144,6 +152,13 @@ export type FieldActions = {
 	select: Action<HTMLSelectElement>;
 
 	/**
+	 * An action for setting up the attributes & event handlers for a multiple select component.
+	 *
+	 * @usage `<select multiple use:actions.multiSelect>...</select>`
+	 */
+	multiSelect: Action<HTMLSelectElement>;
+
+	/**
 	 * An action for setting up the attributes & event handlers for a textarea component.
 	 *
 	 * @usage `<textarea use:actions.textarea />`
@@ -174,6 +189,7 @@ export type FieldHandlers = {
 	radio: (e: Event) => void;
 	select: (e: Event) => void;
 	multiSelect: (e: Event) => void;
+	multiCheck: (e: Event) => void;
 };
 
 export type CreateFieldActionsProps = {

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { FormPathLeaves, UnwrapEffects, ZodValidation } from "sveltekit-superforms";
+import type { FormPath, FormPathLeaves, UnwrapEffects, ZodValidation } from "sveltekit-superforms";
 import type { SuperForm, formFieldProxy } from "sveltekit-superforms/client";
 import type { AnyZodObject, z } from "zod";
 import type { SuperFormOptions, Validators as SuperFormValidators } from "./super-form-patch";
 import type { ActionResult, Page } from "@sveltejs/kit";
+import type { Writable } from "svelte/store";
 
 export type { SuperFormOptions };
 
@@ -19,9 +20,10 @@ export type ExpandDeep<T> = T extends object
 		: never
 	: T;
 
-export type Form<T extends FormValidation> = {
+export type Form<T extends FormValidation, U extends object = object> = {
 	schema: T;
 	form: SuperForm<T>;
+	formStore: Writable<U>;
 };
 
 export type Arrayable<T> = T | T[];

--- a/src/routes/examples/multi/+page.server.ts
+++ b/src/routes/examples/multi/+page.server.ts
@@ -1,0 +1,9 @@
+import { superValidate } from "sveltekit-superforms/server";
+import type { PageServerLoad } from "./$types.js";
+import { multiSelectSchema } from "../schemas.js";
+
+export const load: PageServerLoad = async () => {
+	return {
+		form: superValidate(multiSelectSchema)
+	};
+};

--- a/src/routes/examples/multi/+page.svelte
+++ b/src/routes/examples/multi/+page.svelte
@@ -4,6 +4,8 @@
 	import { multiSelectSchema } from "../schemas.js";
 	import { Button } from "@/components/ui/button/index.js";
 	export let data: PageData;
+
+	const colors = ["green", "blue", "orange", "red"];
 </script>
 
 <div class="flex flex-col h-full min-h-screen w-full items-center py-28">
@@ -18,11 +20,23 @@
 		<Form.FieldMulti {config} name="notifications" let:handlers let:attrs>
 			<div class="grid gap-2">
 				<Form.Label>Notifications</Form.Label>
-				<select {...attrs.input} on:change={handlers.multiSelect} multiple>
+				<select {...attrs.input} on:change={handlers.multiSelect} multiple class="bg-transparent">
 					<option value="all">All</option>
 					<option value="mentions">Mentions</option>
 					<option value="none">None</option>
 				</select>
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.FieldMulti>
+		<Form.FieldMulti {config} name="colors" let:handlers>
+			<div class="grid gap-2">
+				<Form.Label>Colors</Form.Label>
+				{#each colors as color}
+					<div class="flex items-center gap-4">
+						<input id={color} type="checkbox" value={color} on:change={handlers.multiCheck} />
+						<label for={color}>{color}</label>
+					</div>
+				{/each}
 				<Form.Validation class="text-destructive" />
 			</div>
 		</Form.FieldMulti>

--- a/src/routes/examples/multi/+page.svelte
+++ b/src/routes/examples/multi/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { Form } from "@/lib/index.js";
+	import type { PageData } from "./$types.js";
+	import { multiSelectSchema } from "../schemas.js";
+	import { Button } from "@/components/ui/button/index.js";
+	export let data: PageData;
+</script>
+
+<div class="flex flex-col h-full min-h-screen w-full items-center py-28">
+	<h1 class="text-3xl font-semibold tracking-tight pb-8">Account Settings</h1>
+	<Form.Root
+		schema={multiSelectSchema}
+		form={data.form}
+		debug={true}
+		let:config
+		class="container max-w-[750px] mx-auto flex flex-col gap-8"
+	>
+		<Form.FieldMulti {config} name="notifications" let:handlers let:attrs>
+			<div class="grid gap-2">
+				<Form.Label>Notifications</Form.Label>
+				<select {...attrs.input} on:change={handlers.multiSelect} multiple>
+					<option value="all">All</option>
+					<option value="mentions">Mentions</option>
+					<option value="none">None</option>
+				</select>
+				<Form.Validation class="text-destructive" />
+			</div>
+		</Form.FieldMulti>
+		<Button type="submit">Submit</Button>
+	</Form.Root>
+</div>

--- a/src/routes/examples/schemas.ts
+++ b/src/routes/examples/schemas.ts
@@ -40,3 +40,12 @@ export const simpleFormSchema = z.object({
 			message: "You need to accept the terms and conditions"
 		})
 });
+
+export const multiSelectSchema = z.object({
+	notifications: z
+		.array(z.enum(["all", "mentions", "none"]), {
+			required_error: "You need to select a notification type"
+		})
+		.min(1, "You need to select at least one notification type"),
+	colors: z.array(z.string()).min(2, "You need to select at least two colors")
+});


### PR DESCRIPTION
Closes #27 

This PR introduces a new component, `<Form.FieldMulti />` which should be used in place of `<Form.Field />` for fields with array types in your schema.

I've also introduced two additional handlers, which are `multiCheck` & `multiSelect`, which can be applied to the checkbox inputs and select elements within a `Form.FieldMulti` and will handle updating the value store accordingly. 