### PR TITLE
Fix the typing for tag

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,7 +47,7 @@ export type DescriptionProps = {
 	 *
 	 * @default "p"
 	 */
-	tag?: "string";
+	tag?: keyof HTMLElementTagNameMap;
 } & HTMLAttributes<HTMLElement>;
 
 export type ValidationProps = {
@@ -56,7 +56,7 @@ export type ValidationProps = {
 	 *
 	 * @default "p"
 	 */
-	tag?: "string";
+	tag?: keyof HTMLElementTagNameMap;
 } & HTMLAttributes<HTMLElement>;
 
 export type RadioProps = HTMLInputAttributes;


### PR DESCRIPTION
The tag type was specified as `"string"` previously, which means that any value other than the string literal "string" will give a type error, which is clearly not desired. While we could easily fix this by setting the type to `string`, we can do better by specifying `keyof HTMLElementTagNameMap` which is only the tags for valid html elements.