### PR TITLE
New Component: `<Form.Control />`

### DIFF
--- a/.changeset/light-timers-press.md
+++ b/.changeset/light-timers-press.md
@@ -1,0 +1,5 @@
+---
+"formsnap": minor
+---
+
+New Component: `<Form.Control />`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: "18.x"
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/src/components/ui/select/select.svelte
+++ b/src/components/ui/select/select.svelte
@@ -7,6 +7,6 @@
 	export let open: $$Props["open"] = undefined;
 </script>
 
-<SelectPrimitive.Root bind:selected bind:open {...$$restProps}>
-	<slot />
+<SelectPrimitive.Root bind:selected bind:open {...$$restProps} let:ids>
+	<slot {ids} />
 </SelectPrimitive.Root>

--- a/src/lib/components/form-control.svelte
+++ b/src/lib/components/form-control.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { getFormField } from "@/lib/index.js";
+	import type { ControlProps } from "../types.js";
+	import { hiddenInputStyles } from "../internal/style.js";
+
+	type $$Props = ControlProps;
+
+	/*
+	 * Optionally provide a custom ID for the form control,
+	 * which is used to link the label, description, and validation
+	 * messages to the form control.
+	 *
+	 * If no ID is provided, a random ID will be generated.
+	 */
+	export let id: string | undefined = undefined;
+
+	const { errors, attrStore, value, name, ids } = getFormField();
+
+	$: if (id) {
+		ids.update((curr) => {
+			if (id) {
+				return {
+					...curr,
+					input: id
+				};
+			}
+			return curr;
+		});
+	}
+
+	$: attrs = {
+		"data-fs-control": "",
+		"data-fs-error": $errors ? "" : undefined,
+		...$attrStore
+	};
+</script>
+
+<slot {attrs} />
+<input {name} bind:value={$value} style={hiddenInputStyles} />

--- a/src/lib/components/form-radio.svelte
+++ b/src/lib/components/form-radio.svelte
@@ -3,7 +3,7 @@
 	import type { RadioProps } from "../types.js";
 
 	type $$Props = RadioProps;
-	const { actions, errors } = getFormField();
+	const { actions, errors,  } = getFormField();
 	$: attrs = {
 		"data-fs-radio": "",
 		"data-fs-error": $errors ? "" : undefined

--- a/src/lib/components/form.svelte
+++ b/src/lib/components/form.svelte
@@ -47,12 +47,12 @@
 	export let asChild = false;
 	export let debug = false;
 
-	$: superFrm = superForm(form, optionsWithDefaults);
+	const superFrm = superForm(form, optionsWithDefaults);
 
-	$: setContext(FORM_CONTEXT, superFrm);
-	$: setContext(FORM_FIELD_SCHEMA, schema);
+	setContext(FORM_CONTEXT, superFrm);
+	setContext(FORM_FIELD_SCHEMA, schema);
 
-	$: ({
+	const {
 		enhance,
 		form: formStore,
 		allErrors,
@@ -69,7 +69,7 @@
 		formId,
 		restore,
 		capture
-	} = superFrm);
+	} = superFrm;
 
 	let config: Form<T> = {
 		form: superFrm,

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -8,5 +8,18 @@ import Textarea from "./form-textarea.svelte";
 import Select from "./form-select.svelte";
 import Checkbox from "./form-checkbox.svelte";
 import Radio from "./form-radio.svelte";
+import Control from "./form-control.svelte";
 
-export { Root, Field, Label, Description, Validation, Input, Textarea, Select, Checkbox, Radio };
+export {
+	Root,
+	Field,
+	Label,
+	Description,
+	Validation,
+	Input,
+	Textarea,
+	Select,
+	Checkbox,
+	Radio,
+	Control
+};

--- a/src/lib/helpers/get-form-control.ts
+++ b/src/lib/helpers/get-form-control.ts
@@ -1,0 +1,7 @@
+import type { Writable } from "svelte/store";
+import { FORM_CONTROL_CONTEXT } from "$lib/internal/index.js";
+import { getContext } from "svelte";
+
+export function getFormControl() {
+	return getContext<Writable<string | undefined>>(FORM_CONTROL_CONTEXT);
+}

--- a/src/lib/helpers/index.ts
+++ b/src/lib/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from "./get-form-field.js";
 export * from "./get-form.js";
 export * from "./get-form-schema.js";
+export * from "./get-form-control.js";

--- a/src/lib/internal/form-field/create-control.ts
+++ b/src/lib/internal/form-field/create-control.ts
@@ -1,0 +1,8 @@
+import { setContext } from "svelte";
+import type { Writable } from "svelte/store";
+
+export const FORM_CONTROL_CONTEXT = "FormControl";
+
+export function createFormControl(controlIdStore: Writable<string | undefined>) {
+	setContext(FORM_CONTROL_CONTEXT, controlIdStore);
+}

--- a/src/lib/internal/form-field/create-field.ts
+++ b/src/lib/internal/form-field/create-field.ts
@@ -1,25 +1,25 @@
 import type { FormPathLeaves, UnwrapEffects, ZodValidation } from "sveltekit-superforms";
 import type { AnyZodObject, z } from "zod";
-import { formFieldProxy } from "sveltekit-superforms/client";
+import { get, writable, type Writable } from "svelte/store";
+import { createFieldActions, createFieldHandlers } from "@/lib/internal/index.js";
+import type { ErrorsStore, GetFieldAttrsProps } from "@/lib/internal/index.js";
+import type { CreateFormFieldReturn, FieldAttrStore, FieldContext, FieldIds } from "./types.js";
 import { setContext } from "svelte";
-import { writable } from "svelte/store";
-import { createFieldActions, createFieldHandlers, createIds } from "@/lib/internal/index.js";
-import type { Form, GetFieldAttrsProps } from "@/lib/internal/index.js";
-import type { CreateFormFieldReturn, FieldAttrStore, FieldContext } from "./types.js";
 
 export const FORM_FIELD_CONTEXT = "FormField";
 
 export function createFormField<
 	T extends ZodValidation<AnyZodObject>,
 	Path extends FormPathLeaves<z.infer<UnwrapEffects<T>>>
->(form: Form<T>, name: Path): CreateFormFieldReturn<T, Path> {
-	const superFormStores = formFieldProxy<T, Path>(form.form, name);
-	const attrStore: FieldAttrStore = writable({});
+>(
+	name: Path,
+	attrStore: FieldAttrStore,
+	value: Writable<unknown>,
+	errors: ErrorsStore,
+	ids: Writable<FieldIds>
+): CreateFormFieldReturn {
 	const hasValidation = writable(false);
 	const hasDescription = writable(false);
-
-	const { errors, value } = superFormStores;
-	const ids = createIds();
 
 	const actions = createFieldActions({
 		ids,
@@ -31,9 +31,6 @@ export function createFormField<
 	});
 
 	const setValue = (v: unknown) => {
-		//@ts-expect-error - do we leave this as is, or do we want to force the type to match the schema?
-		// Pros: we don't have to deal with type narrowing inside the `setValue` function, and we're runtime validating the type with zod anyways.
-		// Cons: we're not forcing the type to match the schema so more issues could occur.
 		value.set(v);
 	};
 
@@ -56,33 +53,37 @@ export function createFormField<
 
 	function getFieldAttrs<T>(props: GetFieldAttrsProps<T>) {
 		const { val, errors, constraints, hasValidation, hasDescription } = props;
+		const $ids = get(ids);
 		const describedBy = errors
-			? `${hasValidation ? ids.validation : ""} ${hasDescription ? ids.description : ""}`
-			: ids.description
-			? ids.description
+			? `${hasValidation ? $ids.validation : ""} ${hasDescription ? $ids.description : ""}`
+			: hasDescription
+			? $ids.description
 			: undefined;
 
-		return {
+		const attrs = {
 			"aria-invalid": errors ? true : undefined,
 			"aria-describedby": describedBy,
 			"aria-required": !!constraints?.required,
 			"data-invalid": errors ? true : undefined,
 			"data-valid": errors ? undefined : true,
 			name,
-			id: ids.input,
+			id: $ids.input,
 			value: val
 		} as const;
+
+		attrStore.set(attrs);
+
+		return attrs;
 	}
 
 	return {
-		superFormStores,
 		getFieldAttrs,
 		actions,
-		ids,
 		attrStore,
 		hasDescription,
 		hasValidation,
 		handlers,
-		setValue
+		setValue,
+		context
 	};
 }

--- a/src/lib/internal/form-field/create-ids.ts
+++ b/src/lib/internal/form-field/create-ids.ts
@@ -2,13 +2,16 @@ import type { FieldIds } from "./types.js";
 
 /**
  * Creates an object of ids for the form field's elements.
+ *
+ * Optionally pass in a `controlId` to use as the primary id
+ * for the field/input.
  */
-export function createIds(): FieldIds {
+export function createIds(controlId?: string): FieldIds {
 	const input = Math.random().toString(36).slice(3);
 	const description = `${input}-description`;
 	const validation = `${input}-validation`;
 	return {
-		input,
+		input: controlId ? controlId : input,
 		description,
 		validation
 	};

--- a/src/lib/internal/form-field/index.ts
+++ b/src/lib/internal/form-field/index.ts
@@ -2,4 +2,5 @@ export * from "./create-actions.js";
 export * from "./create-field.js";
 export * from "./create-handlers.js";
 export * from "./create-ids.js";
+export * from "./create-control.js";
 export * from "./types.js";

--- a/src/lib/internal/form-field/types.ts
+++ b/src/lib/internal/form-field/types.ts
@@ -1,22 +1,16 @@
-import type { FormPathLeaves, UnwrapEffects, ZodValidation } from "sveltekit-superforms";
-import type { AnyZodObject, z } from "zod";
-import type { FieldAttrs, FormStores, GetFieldAttrsProps } from "../types.js";
+import type { FieldAttrs, GetFieldAttrsProps } from "../types.js";
 import type { Writable } from "svelte/store";
 import type { Action } from "svelte/action";
 
-export type CreateFormFieldReturn<
-	T extends ZodValidation<AnyZodObject>,
-	Path extends FormPathLeaves<z.infer<UnwrapEffects<T>>>
-> = {
-	superFormStores: FormStores<T, Path>;
+export type CreateFormFieldReturn = {
 	getFieldAttrs: <T>(props: GetFieldAttrsProps<T>) => FieldAttrs<T>;
 	actions: FieldActions;
-	ids: FieldIds;
 	attrStore: FieldAttrStore;
 	hasValidation: Writable<boolean>;
 	hasDescription: Writable<boolean>;
 	handlers: FieldHandlers;
 	setValue: FieldValueSetter;
+	context: FieldContext;
 };
 
 export type FieldContext = {
@@ -31,7 +25,7 @@ export type FieldContext = {
 	 * Use this object to set appropriate aria and htmlFor attributes
 	 * when composing your own form field components.
 	 */
-	ids: FieldIds;
+	ids: Writable<FieldIds>;
 
 	/**
 	 * A writable store containing an array of validation errors
@@ -176,7 +170,7 @@ export type FieldHandlers = {
 };
 
 export type CreateFieldActionsProps = {
-	ids: FieldIds;
+	ids: Writable<FieldIds>;
 	attrs: FieldAttrStore;
 	hasValidation: Writable<boolean>;
 	hasDescription: Writable<boolean>;

--- a/src/lib/internal/style.ts
+++ b/src/lib/internal/style.ts
@@ -1,0 +1,16 @@
+export function styleToString(style: Record<string, number | string | undefined>): string {
+	return Object.keys(style).reduce((str, key) => {
+		if (style[key] === undefined) return str;
+		return str + `${key}:${style[key]};`;
+	}, "");
+}
+
+export const hiddenInputStyles = styleToString({
+	position: "absolute",
+	width: "25px",
+	height: "25px",
+	opacity: "0",
+	margin: "0px",
+	pointerEvents: "none",
+	transform: "translateX(-100%)"
+});

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -4,6 +4,7 @@ import type { SuperForm, formFieldProxy } from "sveltekit-superforms/client";
 import type { AnyZodObject, z } from "zod";
 import type { SuperFormOptions, Validators as SuperFormValidators } from "./super-form-patch";
 import type { ActionResult, Page } from "@sveltejs/kit";
+import type { Writable } from "svelte/store";
 
 export type { SuperFormOptions };
 
@@ -85,3 +86,18 @@ export type SveltePage<
 	Params extends Record<string, string> = Record<string, string>,
 	RouteId extends string | null = string | null
 > = Page<Params, RouteId>;
+
+export type ConstraintsStore = Writable<
+	| Partial<{
+			pattern: string;
+			min: string | number;
+			max: string | number;
+			required: boolean;
+			step: number | "any";
+			minlength: number;
+			maxlength: number;
+	  }>
+	| undefined
+>;
+
+export type ErrorsStore = Writable<string[] | undefined>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,9 @@ export type FieldProps<T extends AnyZodObject = AnyZodObject, Path = FormFieldNa
 };
 
 export type InputProps = HTMLInputAttributes;
+export type ControlProps = {
+	id?: string;
+};
 export type CheckboxProps = HTMLInputAttributes;
 
 export type DescriptionProps = {

--- a/src/routes/examples/custom-and-formsnap/+page.svelte
+++ b/src/routes/examples/custom-and-formsnap/+page.svelte
@@ -71,18 +71,22 @@
 			<div class="grid gap-2">
 				<Form.Label>Language</Form.Label>
 				<Select.Root
+					let:ids
 					selected={{ value, label: languages[value] }}
 					onSelectedChange={(v) => setValue(v?.value)}
 				>
-					<Select.Trigger {...attrs.input}>
-						<Select.Value placeholder="Select a language" />
-					</Select.Trigger>
+					<Form.Control id={ids.trigger} let:attrs>
+						<Select.Trigger {...attrs}>
+							<Select.Value placeholder="Select a language" />
+						</Select.Trigger>
+					</Form.Control>
 					<Select.Content>
 						{#each Object.entries(languages) as [value, lang]}
 							<Select.Item {value}>{lang}</Select.Item>
 						{/each}
 					</Select.Content>
 				</Select.Root>
+				<Form.Validation />
 			</div>
 		</Form.Field>
 		<Form.Field {config} name="usage" let:attrs let:setValue>

--- a/src/routes/examples/schemas.ts
+++ b/src/routes/examples/schemas.ts
@@ -40,3 +40,9 @@ export const simpleFormSchema = z.object({
 			message: "You need to accept the terms and conditions"
 		})
 });
+
+export const sinkFormSchema = z.object({
+	language: z.enum(["en", "es", "fr"], {
+		required_error: "You need to select a language."
+	})
+});

--- a/src/routes/examples/sink/+page.server.ts
+++ b/src/routes/examples/sink/+page.server.ts
@@ -1,17 +1,17 @@
 import { superValidate } from "sveltekit-superforms/server";
 import type { PageServerLoad } from "./$types.js";
-import { someFormSchema } from "../schemas.js";
+import { sinkFormSchema } from "../schemas.js";
 import { fail, type Actions } from "@sveltejs/kit";
 
 export const load: PageServerLoad = async () => {
 	return {
-		form: superValidate(someFormSchema)
+		form: superValidate(sinkFormSchema)
 	};
 };
 
 export const actions: Actions = {
 	default: async (event) => {
-		const form = await superValidate(event, someFormSchema);
+		const form = await superValidate(event, sinkFormSchema);
 
 		if (!form.valid) {
 			return fail(400, { form });

--- a/src/routes/examples/sink/+page.svelte
+++ b/src/routes/examples/sink/+page.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { Form } from "@/lib/index.js";
+	import type { PageData } from "./$types.js";
+	import { sinkFormSchema } from "../schemas.js";
+	import { Button } from "@/components/ui/button/index.js";
+	import * as Select from "@/components/ui/select/index.js";
+	export let data: PageData;
+
+	const languages = {
+		en: "English",
+		es: "Spanish",
+		fr: "French"
+	} as const;
+</script>
+
+<div class="flex flex-col h-full min-h-screen w-full items-center py-28">
+	<h1 class="text-3xl font-semibold tracking-tight pb-8">Account Settings</h1>
+	<Form.Root
+		schema={sinkFormSchema}
+		form={data.form}
+		debug={true}
+		let:config
+		class="container max-w-[750px] mx-auto flex flex-col gap-8"
+	>
+		<Form.Field {config} name="language" let:attrs let:setValue>
+			{@const { value } = attrs.input}
+			<div class="grid gap-2">
+				<Form.Label>Language</Form.Label>
+				<Select.Root
+					let:ids
+					selected={{ value, label: languages[value] }}
+					onSelectedChange={(v) => setValue(v?.value)}
+				>
+					<Form.Control id={ids.trigger} let:attrs>
+						<Select.Trigger {...attrs}>
+							<Select.Value placeholder="Select a language" />
+						</Select.Trigger>
+					</Form.Control>
+					<Select.Content>
+						{#each Object.entries(languages) as [value, lang]}
+							<Select.Item {value}>{lang}</Select.Item>
+						{/each}
+					</Select.Content>
+				</Select.Root>
+				<Form.Validation />
+			</div>
+		</Form.Field>
+		<Button type="submit">Submit</Button>
+	</Form.Root>
+</div>


### PR DESCRIPTION
`Form.Control` is useful when you want to use a component other than your typical form component.

For example, you may have a button acting as the primary form control, so to get the right attributes and also automatically include an input bound to the value, you could do something like this:

```svelte
<Form.Field>
	<Form.Label>My Label</Form.Label>
	<Form.Control let:attrs>
		<Button {...attrs}>Hello</Button>
	</Form.Control>
</Form.Field>
```

Now when the label is pressed, the button will trigger, and when the form is invalid, focus will be brought to the button (if that field is invalid).

You can also pass in a custom id to use, if your element ids are controlled elsewhere:

```svelte
<Form.Field>
	<Form.Label>My Label</Form.Label>
	<Form.Control let:attrs id="123">
		<Button {...attrs}>Hello</Button>
	</Form.Control>
</Form.Field>
```