### PR TITLE
Feat: Controlled `SuperForm` usage

### DIFF
--- a/.changeset/fifty-dryers-heal.md
+++ b/.changeset/fifty-dryers-heal.md
@@ -1,0 +1,5 @@
+---
+"formsnap": minor
+---
+
+Feat: Controlled `SuperForm` usage

--- a/content/api-reference/form-control.md
+++ b/content/api-reference/form-control.md
@@ -1,0 +1,18 @@
+---
+title: <Form.Control />
+description: Use components that aren't traditional form elements to control the form.
+---
+
+The `<Form.Control />` component is designed for use cases where you may have a component that isn't a traditional form element, but you still want to have all the accessibility and state management that comes with formsnap.
+
+For example, let's say we're using a component which has a button that opens a popover with a combobox inside of it. If there is a validation issue with that field, we want to be able to provide that feedback to the user by potentially autofocusing the button, as well as ensuring the correct `aria-` attributes are applied to that button.
+
+```svelte
+<Form.Control id="buttonId" let:attrs>
+	<button {...attrs} role="combobox" id="buttonId">
+		{value}
+	</button>
+</Form.Control>
+```
+
+To see a full example of the `<Form.Control />` component in action, checkout the [Combobox form example](https://www.shadcn-svelte.com/docs/components/combobox#form) for shadcn-svelte.

--- a/src/lib/components/form-control.svelte
+++ b/src/lib/components/form-control.svelte
@@ -5,13 +5,6 @@
 
 	type $$Props = ControlProps;
 
-	/*
-	 * Optionally provide a custom ID for the form control,
-	 * which is used to link the label, description, and validation
-	 * messages to the form control.
-	 *
-	 * If no ID is provided, a random ID will be generated.
-	 */
 	export let id: string | undefined = undefined;
 
 	const { errors, attrStore, value, name, ids } = getFormField();

--- a/src/lib/components/form.svelte
+++ b/src/lib/components/form.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" context="module">
-	import type { ZodValidation } from "sveltekit-superforms";
+	import type { UnwrapEffects, ZodValidation } from "sveltekit-superforms";
 	import type { AnyZodObject } from "zod";
 	import type { Form } from "@/lib/internal/index.js";
 
@@ -11,28 +11,199 @@
 
 <script lang="ts" generics="T extends Validation = Validation, M = any">
 	import { FORM_FIELD_SCHEMA } from "../helpers/get-form-schema";
-
 	import type { HTMLFormAttributes } from "svelte/elements";
 	import { setContext } from "svelte";
 	import type { FormEvents, FormOptions } from "@/lib/types.js";
 	import { FORM_CONTEXT } from "@/lib/internal/index.js";
-	import { superForm } from "sveltekit-superforms/client";
+	import { superForm, type SuperForm } from "sveltekit-superforms/client";
 	import SuperDebug from "sveltekit-superforms/client/SuperDebug.svelte";
 	import type { SuperValidated } from "sveltekit-superforms";
 
 	type $$Events = FormEvents;
 
-	type $$Props = {
+	type BaseProps = {
+		/**
+		 * The schema representing the structure of the form, used to provide
+		 * validation by default (uncontrolled), and type information to the form.
+		 *
+		 * @see https://zod.dev
+		 */
 		schema: T;
-		form: SuperValidated<T, M>;
-		options?: FormOptions<T, M>;
-		asChild?: boolean;
-		debug?: boolean;
-	} & HTMLFormAttributes;
 
+		/**
+		 * Whether to delegate rendering the `form` element which enables
+		 * you to use your own `<form />` element. You can then leverage the
+		 * `enhance` and `attrs` slot props to bring your form element to life.
+		 * @default false
+		 *
+		 * @example
+		 * ```svelte
+		 * <Form.Root {schema} form={data.form} asChild let:enhance let:attrs>
+		 * 	<form use:enhance {...attrs}>
+		 * 		<!-- ... -->
+		 * 	</form>
+		 * </Form.Root>
+		 * ```
+		 *
+		 * @see https://formsnap.dev/docs/headless-usage
+		 */
+		asChild?: boolean;
+
+		/**
+		 * Optionally display the `SuperDebug` component beneath your
+		 * form for debugging purposes.
+		 *
+		 * @see https://formsnap.dev/docs/debug-mode
+		 */
+		debug?: boolean;
+	};
+
+	type ControlledProps = {
+		/**
+		 * Whether the form is controlled or not. Controlled forms
+		 * are used when you want to initialize the `superForm` yourself.
+		 *
+		 * When set to true, you need to pass the object returned from the
+		 * `superForm` function as the `form` prop. When false, you just pass
+		 * the `SuperValidated` (data.form) object as the `form` prop.
+		 *
+		 * @example <caption>Example of controlled usage</caption>
+		 * ```typescript
+		 * // script tag
+		 * import { superForm } from "sveltekit-superforms/client";
+		 * import { schema } from "./schema";
+		 * export let data;
+		 * const superFrm = superForm(data.form, { validators: schema })
+		 * // closing script tag
+		 * ```
+		 *
+		 * ```svelte
+		 * <Form.Root form={superFrm} controlled>
+		 * 	<!-- ... -->
+		 * </Form.Root>
+		 * ```
+		 *
+		 * @example <caption>Example of uncontrolled (default) usage</caption>
+		 *  ```svelte
+		 * <Form.Root form={data.form}>
+		 * 	<!-- ... -->
+		 * </Form.Root>
+		 * ```
+		 */
+		controlled: true;
+
+		/**
+		 * The `SuperForm` object returned from the `superForm` function when
+		 * the `controlled` prop is set to true. Otherwise, you pass the form
+		 * returned from the load function.
+		 *
+		 * @example <caption>Example of controlled usage</caption>
+		 * ```typescript
+		 * // script tag
+		 * import { superForm } from "sveltekit-superforms/client";
+		 * import { schema } from "./schema";
+		 * export let data;
+		 * const superFrm = superForm(data.form, { validators: schema })
+		 * // closing script tag
+		 * ```
+		 *
+		 * ```svelte
+		 * <Form.Root form={superFrm} controlled>
+		 * 	<!-- ... -->
+		 * </Form.Root>
+		 * ```
+		 *
+		 * @example <caption>Example of uncontrolled (default) usage</caption>
+		 *  ```svelte
+		 * <Form.Root form={data.form}>
+		 * 	<!-- ... -->
+		 * </Form.Root>
+		 * ```
+		 */
+		form: SuperForm<UnwrapEffects<T>, M>;
+	};
+
+	type UncontrolledProps = {
+		/**
+		 * Whether the form is controlled or not. Controlled forms
+		 * are used when you want to initialize the `superForm` yourself.
+		 *
+		 * When set to true, you need to pass the object returned from the
+		 * `superForm` function as the `form` prop. When false, you just pass
+		 * the `SuperValidated` (data.form) object as the `form` prop.
+		 *
+		 * @example <caption>Example of controlled usage</caption>
+		 * ```typescript
+		 * // script tag
+		 * import { superForm } from "sveltekit-superforms/client";
+		 * import { schema } from "./schema";
+		 * export let data;
+		 * const superFrm = superForm(data.form, { validators: schema })
+		 * // closing script tag
+		 * ```
+		 *
+		 * ```svelte
+		 * <Form.Root form={superFrm} controlled>
+		 * 	<!-- ... -->
+		 * </Form.Root>
+		 * ```
+		 *
+		 * @example <caption>Example of uncontrolled (default) usage</caption>
+		 *  ```svelte
+		 * <Form.Root form={data.form} controlled>
+		 * 	<!-- ... -->
+		 * </Form.Root>
+		 * ```
+		 */
+		controlled?: false;
+
+		/**
+		 * The `SuperForm` object returned from the `superForm` function when
+		 * the `controlled` prop is set to true. Otherwise, you pass the form
+		 * returned from the load function.
+		 *
+		 * @example <caption>Example of default usage</caption>
+		 * ```svelte
+		 * <Form.Root form={data.form} controlled>
+		 * 	<!-- ... -->
+		 * </Form.Root>
+		 * ```
+		 *
+		 * @example <caption>Example of controlled usage</caption>
+		 * ```typescript
+		 * // script tag
+		 * import { superForm } from "sveltekit-superforms/client";
+		 * import { schema } from "./schema";
+		 * export let data;
+		 * const superFrm = superForm(data.form, { validators: schema })
+		 * // closing script tag
+		 * ```
+		 *
+		 * ```svelte
+		 * <Form.Root form={superFrm} controlled>
+		 * 	<!-- ... -->
+		 * </Form.Root>
+		 * ```
+		 *
+		 */
+		form: SuperValidated<T, M>;
+
+		/**
+		 * When uncontrolled, you can optionally pass any options
+		 * that you would normally pass to the `superForm` function.
+		 *
+		 * @see https://superforms.rocks/api#superform-options
+		 */
+		options?: FormOptions<T, M>;
+	};
+
+	type $$Props = BaseProps & (ControlledProps | UncontrolledProps) & HTMLFormAttributes;
+
+	/* The schema which defines the form */
 	export let schema: T;
-	export let form: SuperValidated<T, M>;
+	export let form: $$Props["form"];
 	export let options: FormOptions<T, M> = {};
+	export let controlled: $$Props["controlled"] = false;
 
 	const defaultOptions = {
 		validators: schema as FormOptions<T, M>["validators"],
@@ -47,7 +218,18 @@
 	export let asChild = false;
 	export let debug = false;
 
-	const superFrm = superForm(form, optionsWithDefaults);
+	function getSuperForm(
+		controlled: boolean | undefined,
+		form: SuperForm<UnwrapEffects<T>, M> | SuperValidated<T, M>,
+		options: FormOptions<T, M>
+	): SuperForm<UnwrapEffects<T>, M> {
+		if (controlled) {
+			return form as SuperForm<UnwrapEffects<T>, M>;
+		}
+		return superForm(form as SuperValidated<T, M>, options);
+	}
+
+	const superFrm = getSuperForm(controlled, form, optionsWithDefaults);
 
 	setContext(FORM_CONTEXT, superFrm);
 	setContext(FORM_FIELD_SCHEMA, schema);
@@ -127,6 +309,7 @@
 			formValues={$formStore}
 			form={superFrm}
 			{enhance}
+			{attrs}
 			allErrors={$allErrors}
 			delayed={$delayed}
 			errors={$errors}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,13 @@ export type FieldProps<T extends AnyZodObject = AnyZodObject, Path = FormFieldNa
 
 export type InputProps = HTMLInputAttributes;
 export type ControlProps = {
+	/*
+	 * Optionally provide a custom ID for the form control,
+	 * which is used to link the label, description, and validation
+	 * messages to the form control.
+	 *
+	 * If no ID is provided, a random ID will be generated.
+	 */
 	id?: string;
 };
 export type CheckboxProps = HTMLInputAttributes;

--- a/src/routes/examples/schemas.ts
+++ b/src/routes/examples/schemas.ts
@@ -41,13 +41,6 @@ export const simpleFormSchema = z.object({
 		})
 });
 
-export const sinkFormSchema = z.object({
-	language: z.enum(["en", "es", "fr"], {
-		required_error: "You need to select a language."
-	}),
-	dateField: z.coerce.date().nullable()
-});
-
 export const testASchema = z.object({
 	username: z
 		.string()

--- a/src/routes/examples/sink/+page.server.ts
+++ b/src/routes/examples/sink/+page.server.ts
@@ -1,17 +1,17 @@
 import { superValidate } from "sveltekit-superforms/server";
 import type { PageServerLoad } from "./$types.js";
-import { sinkFormSchema } from "./+page.svelte";
+import { schema } from "./+page.svelte";
 import { fail, type Actions } from "@sveltejs/kit";
 
 export const load: PageServerLoad = async () => {
 	return {
-		form: superValidate(sinkFormSchema)
+		form: superValidate(schema)
 	};
 };
 
 export const actions: Actions = {
 	default: async (event) => {
-		const form = await superValidate(event, sinkFormSchema);
+		const form = await superValidate(event, schema);
 
 		if (!form.valid) {
 			return fail(400, { form });

--- a/src/routes/examples/sink/+page.server.ts
+++ b/src/routes/examples/sink/+page.server.ts
@@ -1,6 +1,6 @@
 import { superValidate } from "sveltekit-superforms/server";
 import type { PageServerLoad } from "./$types.js";
-import { sinkFormSchema } from "../schemas.js";
+import { sinkFormSchema } from "./+page.svelte";
 import { fail, type Actions } from "@sveltejs/kit";
 
 export const load: PageServerLoad = async () => {

--- a/src/routes/examples/sink/+page.svelte
+++ b/src/routes/examples/sink/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" context="module">
 	import { z } from "zod";
-	export const sinkFormSchema = z.object({
+	export const schema = z.object({
 		latitude: z.coerce.number(),
 		longitude: z.coerce.number(),
 		num: z.coerce.number()
@@ -16,8 +16,7 @@
 	export let data: PageData;
 
 	const superFrm = superForm(data.form, {
-		validators: sinkFormSchema,
-		dataType: "json"
+		validators: schema
 	});
 
 	onMount(() => {
@@ -46,10 +45,10 @@
 	<h1 class="text-3xl font-semibold tracking-tight pb-8">Account Settings</h1>
 	<Button on:click={getRandomNumber}>Random num</Button>
 	<Form.Root
-		schema={sinkFormSchema}
+		{schema}
 		form={superFrm}
-		controlled={true}
-		debug={true}
+		controlled
+		debug
 		let:config
 		class="container max-w-[750px] mx-auto flex flex-col gap-8"
 	>

--- a/src/routes/examples/sink/+page.svelte
+++ b/src/routes/examples/sink/+page.svelte
@@ -1,57 +1,71 @@
+<script lang="ts" context="module">
+	import { z } from "zod";
+	export const sinkFormSchema = z.object({
+		latitude: z.coerce.number(),
+		longitude: z.coerce.number(),
+		num: z.coerce.number()
+	});
+</script>
+
 <script lang="ts">
 	import { Form } from "@/lib/index.js";
 	import type { PageData } from "./$types.js";
-	import { sinkFormSchema } from "../schemas.js";
 	import { Button } from "@/components/ui/button/index.js";
-	import * as Select from "@/components/ui/select/index.js";
-	import DateInput from "./DateInput.svelte";
+	import { onMount } from "svelte";
+	import { superForm } from "sveltekit-superforms/client";
 	export let data: PageData;
 
-	const languages = {
-		en: "English",
-		es: "Spanish",
-		fr: "French"
-	} as const;
+	const superFrm = superForm(data.form, {
+		validators: sinkFormSchema,
+		dataType: "json"
+	});
+
+	onMount(() => {
+		navigator.geolocation.getCurrentPosition((position) => {
+			superFrm.form.update((curr) => {
+				return {
+					...curr,
+					latitude: position.coords.latitude,
+					longitude: position.coords.longitude
+				};
+			});
+		});
+	});
+
+	function getRandomNumber() {
+		superFrm.form.update((curr) => {
+			return {
+				...curr,
+				num: Math.random() * 100
+			};
+		});
+	}
 </script>
 
 <div class="flex flex-col h-full min-h-screen w-full items-center py-28">
 	<h1 class="text-3xl font-semibold tracking-tight pb-8">Account Settings</h1>
+	<Button on:click={getRandomNumber}>Random num</Button>
 	<Form.Root
 		schema={sinkFormSchema}
-		form={data.form}
+		form={superFrm}
+		controlled={true}
 		debug={true}
 		let:config
-		options={{ dataType: "json" }}
 		class="container max-w-[750px] mx-auto flex flex-col gap-8"
 	>
-		<Form.Field {config} name="language" let:attrs let:setValue>
-			{@const { value } = attrs.input}
-			<div class="grid gap-2">
-				<Form.Label>Language</Form.Label>
-				<Select.Root
-					let:ids
-					selected={{ value, label: languages[value] }}
-					onSelectedChange={(v) => setValue(v?.value)}
-				>
-					<Form.Control id={ids.trigger} let:attrs>
-						<Select.Trigger {...attrs}>
-							<Select.Value placeholder="Select a language" />
-						</Select.Trigger>
-					</Form.Control>
-					<Select.Content>
-						{#each Object.entries(languages) as [value, lang]}
-							<Select.Item {value}>{lang}</Select.Item>
-						{/each}
-					</Select.Content>
-				</Select.Root>
-				<Form.Validation />
-			</div>
+		<Form.Field {config} name="latitude">
+			<Form.Label>Latitude</Form.Label>
+			<Form.Input type="number" />
+			<Form.Validation />
 		</Form.Field>
-		<Form.Field {config} name="dateField">
-			<Form.Label>Date field</Form.Label>
-			<div class="max-w-[14rem]">
-				<DateInput type="datetime-local" />
-			</div>
+		<Form.Field {config} name="longitude">
+			<Form.Label>Longitude</Form.Label>
+			<Form.Input type="number" />
+			<Form.Validation />
+		</Form.Field>
+		<Form.Field {config} name="num">
+			<Form.Label>Random Num</Form.Label>
+			<Form.Input type="number" />
 			<Form.Validation />
 		</Form.Field>
 		<Button type="submit">Submit</Button>


### PR DESCRIPTION
This PR introduces a feature that closes a lot of outstanding issues and will make the library more robust overall. It should not introduce any breaking changes to existing projects, if it does please [open an issue](https://github.com/huntabyte/formsnap/issues/new)

## Controlled Usage
Controlled usage is designed to be used when you need a higher level of control over the form state. To make a form controlled, you simply set the `controlled` prop to `true`, and pass the object returned from the `superForm` function to the `form` prop.

Now rather than initializing the `SuperForm` on your behalf, we simply use what you pass to the `form` prop. This allows you to initialize the form wherever you'd like, as well as control it from outside the `<Form.Root />` component.

When using controlled usage, you still must pass the `schema` for type-safe fields, but you no longer pass the `options` prop, as your options are now passed to the `superForm` function and we do not apply any defaults in this mode.

```svelte
<script lang="ts">
  import { Form } from "formsnap";
  import { schema } from "$lib/schemas";
  import { superForm } from "sveltekit-superforms/client";
  export let data;
 
  const superFrm = superForm(data.form, {
    validators: schema
    // ...
  });
</script>
 
<Form.Root {schema} controlled form={superFrm} let:config>
  <!-- ... -->
</Form.Root>
```

Now it's possible to get all the benefits of Formsnap without sacrificing too much flexibility. For example, as mentioned in #69, if you need to set some values within an `onMount`, that can be accomplished like so:

```svelte
<script lang="ts" context="module">
	import { z } from "zod";
	export const schema = z.object({
		latitude: z.coerce.number(),
		longitude: z.coerce.number(),
	});
</script>

<script lang="ts">
	import { Form } from "@/lib/index.js";
	import type { PageData } from "./$types.js";
	import { onMount } from "svelte";
	import { superForm } from "sveltekit-superforms/client";
	export let data: PageData;

	const superFrm = superForm(data.form, {
		validators: schema
	});

	onMount(() => {
		navigator.geolocation.getCurrentPosition((position) => {
			superFrm.form.update((curr) => {
				return {
					...curr,
					latitude: position.coords.latitude,
					longitude: position.coords.longitude
				};
			});
		});
	});
</script>

<Form.Root
	{schema}
	form={superFrm}
	controlled
	let:config
>
	<Form.Field {config} name="latitude">
		<Form.Label>Latitude</Form.Label>
		<Form.Input type="number" />
		<Form.Validation />
	</Form.Field>
	<Form.Field {config} name="longitude">
		<Form.Label>Longitude</Form.Label>
		<Form.Input type="number" />
		<Form.Validation />
	</Form.Field>
	<button type="submit">Submit</Button>
</Form.Root>
```



Closes: #69 #43 #54 #59 #57 