### PR TITLE
fix: apply correct data attributes to elements

### DIFF
--- a/.changeset/grumpy-papayas-sparkle.md
+++ b/.changeset/grumpy-papayas-sparkle.md
@@ -1,0 +1,5 @@
+---
+"formsnap": patch
+---
+
+I updated the data-fs-select data attribute assigned to the input, textarea and radio components related to issue #93 (and my own experience). I updated each to their respect data-fs-\* data attribute (data-fs-input, data-fs-textarea, and data-fs-radio).

--- a/.changeset/grumpy-papayas-sparkle.md
+++ b/.changeset/grumpy-papayas-sparkle.md
@@ -2,4 +2,4 @@
 "formsnap": patch
 ---
 
-I updated the data-fs-select data attribute assigned to the input, textarea and radio components related to issue #93 (and my own experience). I updated each to their respect data-fs-\* data attribute (data-fs-input, data-fs-textarea, and data-fs-radio).
+fix: apply correct `data-fs` attributes to elements

--- a/src/lib/components/form-input.svelte
+++ b/src/lib/components/form-input.svelte
@@ -5,7 +5,7 @@
 	type $$Props = InputProps;
 	const { actions, errors, attrStore } = getFormField();
 	$: attrs = {
-		"data-fs-select": "",
+		"data-fs-input": "",
 		"data-fs-error": $errors ? "" : undefined,
 		...$attrStore
 	};

--- a/src/lib/components/form-radio.svelte
+++ b/src/lib/components/form-radio.svelte
@@ -5,7 +5,7 @@
 	type $$Props = RadioProps;
 	const { actions, errors, attrStore } = getFormField();
 	$: attrs = {
-		"data-fs-select": "",
+		"data-fs-radio": "",
 		"data-fs-error": $errors ? "" : undefined,
 		...$attrStore
 	};

--- a/src/lib/components/form-textarea.svelte
+++ b/src/lib/components/form-textarea.svelte
@@ -5,7 +5,7 @@
 	type $$Props = TextareaProps;
 	const { actions, errors, attrStore } = getFormField();
 	$: attrs = {
-		"data-fs-select": "",
+		"data-fs-textarea": "",
 		"data-fs-error": $errors ? "" : undefined,
 		...$attrStore
 	};


### PR DESCRIPTION
I updated the data-fs-select data attribute assigned to the input, textarea and radio components related to issue #93 (and my own experience).  I didn't notice any comments indicated if this was intention, but feel free to reject if it intentional design!  Just wanted to help in case it was just a copy paste error :)

Closes: #93