### PR TITLE
fix: spelling of z.enum() in quick-start

### DIFF
--- a/content/quick-start.md
+++ b/content/quick-start.md
@@ -31,8 +31,8 @@ import { z } from "zod";
 const settingsSchema = z.object({
 	email: z.string().email("Please enter a valid email."),
 	bio: z.string().optional(),
-	theme: z.eum(["light", "dark"]).default("light"),
-	language: z.eum(["en", "es", "fr"]).default("en"),
+	theme: z.enum(["light", "dark"]).default("light"),
+	language: z.enum(["en", "es", "fr"]).default("en"),
 	marketingEmails: z.boolean().default(true)
 });
 ```


### PR DESCRIPTION
Quick fix for spelling `z.enum()` in the quick start section of docs.