### PR TITLE
fix: added missing field to the quick start example

### DIFF
--- a/content/quick-start.md
+++ b/content/quick-start.md
@@ -180,6 +180,10 @@ And that's really all it takes to setup a form field. Let's continue on with the
 		</Form.Description>
 		<Form.Validation />
 	</Form.Field>
+	<Form.Field {config} name="marketingEmails">
+		<Form.Label>Opt in for marketing emails</Form.Label>
+		<Form.Checkbox />
+	</Form.Field>
 	<button type="submit"> Save </button>
 </Form.Root>
 ```


### PR DESCRIPTION
- Added the missing marketingEmails field missing in the quick start example

Also unlike shadcn-svelte it's missing title and instead shows the full url

![image](https://github.com/huntabyte/formsnap/assets/69469790/53a05ca2-f5d2-40e6-9bbf-b64e7cbbb554)

I checked the code and it was same as shadcn docs, if you can point me what to fix i can help you with it 😄 

Also why does it have svelte default logo 😳 (never noticed before)