### PR TITLE
Add support for superforms {_errors: string[]} errors

### DIFF
--- a/.changeset/kind-fireants-collect.md
+++ b/.changeset/kind-fireants-collect.md
@@ -1,0 +1,5 @@
+---
+"formsnap": patch
+---
+
+Adds support for superforms {\_errors?: string[]} syntax

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.45.0",
 		"@typescript-eslint/parser": "^5.45.0",
 		"autoprefixer": "^10.4.14",
-		"bits-ui": "^0.9.0",
+		"bits-ui": "^0.17.0",
 		"clsx": "^2.0.0",
 		"concurrently": "^8.2.1",
 		"contentlayer": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ devDependencies:
     specifier: ^10.4.14
     version: 10.4.15(postcss@8.4.29)
   bits-ui:
-    specifier: ^0.9.0
-    version: 0.9.0(svelte@4.2.0)
+    specifier: ^0.17.0
+    version: 0.17.0(svelte@4.2.0)
   clsx:
     specifier: ^2.0.0
     version: 2.0.0
@@ -902,6 +902,12 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
+  /@internationalized/date@3.5.1:
+    resolution: {integrity: sha512-LUQIfwU9e+Fmutc/DpRTGXSdgYZLBegi4wygCWDSVmUdLTaMHsQyASDiJtREwanwKuQLq0hY76fCJ9J/9I2xOQ==}
+    dependencies:
+      '@swc/helpers': 0.5.6
+    dev: true
+
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1022,16 +1028,17 @@ packages:
       - supports-color
     dev: true
 
-  /@melt-ui/svelte@0.57.2(svelte@4.2.0):
-    resolution: {integrity: sha512-Ul+pebT2wff5rp5xzlXwQ7W6z5YOS9oXsds21dqlE2gUAFBIfN1vIo4IZrTed/FkpCyey90CvHDQYfQvZiNvkA==}
+  /@melt-ui/svelte@0.71.2(svelte@4.2.0):
+    resolution: {integrity: sha512-GDUErhAphEoEOLpcBjQ84BgzRR6M3344fQE4QYFffwT7aedWak7CvNsECgeig1Y5xvfDmeEaFnGlOQXIBucJYw==}
     peerDependencies:
       svelte: '>=3 <5'
     dependencies:
       '@floating-ui/core': 1.4.1
       '@floating-ui/dom': 1.5.1
+      '@internationalized/date': 3.5.1
       dequal: 2.0.3
       focus-trap: 7.5.2
-      nanoid: 4.0.2
+      nanoid: 5.0.5
       svelte: 4.2.0
     dev: true
 
@@ -1438,6 +1445,12 @@ packages:
       dotenv: 16.3.1
     transitivePeerDependencies:
       - encoding
+    dev: true
+
+  /@swc/helpers@0.5.6:
+    resolution: {integrity: sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==}
+    dependencies:
+      tslib: 2.6.2
     dev: true
 
   /@tailwindcss/typography@0.5.9(tailwindcss@3.3.3):
@@ -2092,13 +2105,14 @@ packages:
       file-uri-to-path: 1.0.0
     dev: true
 
-  /bits-ui@0.9.0(svelte@4.2.0):
-    resolution: {integrity: sha512-wEVWMnR4or4t8dY+UP+G4jVugzsfhMcuIrTOoJh8V6t/JcHWne/z1nnBA/yD1E1cn391IUurSatRkv7qTJXMww==}
+  /bits-ui@0.17.0(svelte@4.2.0):
+    resolution: {integrity: sha512-K73jjco1qPmvGXMQtTkZG6K36UmNrPR21u+C1jzoRWmF3NnUfDP4hPJnAci0LosUycfvOxtaHB1M4awvLvQXyQ==}
     peerDependencies:
       svelte: ^4.0.0
     dependencies:
-      '@melt-ui/svelte': 0.57.2(svelte@4.2.0)
-      nanoid: 5.0.2
+      '@internationalized/date': 3.5.1
+      '@melt-ui/svelte': 0.71.2(svelte@4.2.0)
+      nanoid: 5.0.5
       svelte: 4.2.0
     dev: true
 
@@ -5128,14 +5142,8 @@ packages:
     hasBin: true
     dev: true
 
-  /nanoid@4.0.2:
-    resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
-    engines: {node: ^14 || ^16 || >=18}
-    hasBin: true
-    dev: true
-
-  /nanoid@5.0.2:
-    resolution: {integrity: sha512-2ustYUX1R2rL/Br5B/FMhi8d5/QzvkJ912rBYxskcpu0myTHzSZfTr1LAS2Sm7jxRUObRrSBFoyzwAhL49aVSg==}
+  /nanoid@5.0.5:
+    resolution: {integrity: sha512-/Veqm+QKsyMY3kqi4faWplnY1u+VuKO3dD2binyPIybP31DRO29bPF+1mszgLnrR2KqSLceFLBNw0zmvDzN1QQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
     dev: true

--- a/src/lib/components/form-validation.svelte
+++ b/src/lib/components/form-validation.svelte
@@ -5,6 +5,13 @@
 	type $$Props = ValidationProps;
 	export let tag = "p";
 	const { actions, errors, ids } = getFormField();
+
+	$: internalErrors = Array.isArray($errors)
+		? $errors
+		: $errors?._errors
+		? $errors._errors
+		: undefined;
+
 	$: attrs = {
 		"data-fs-validation": "",
 		"data-fs-error": $errors ? "" : undefined,
@@ -13,7 +20,7 @@
 </script>
 
 <svelte:element this={tag} use:actions.validation {...attrs} {...$$restProps}>
-	{#if $errors}
-		{$errors}
+	{#if internalErrors}
+		{internalErrors}
 	{/if}
 </svelte:element>

--- a/src/lib/internal/form-field/types.ts
+++ b/src/lib/internal/form-field/types.ts
@@ -32,7 +32,7 @@ export type FieldContext = {
 	 * if they exist, or undefined if they don't. Useful for displaying
 	 * errors in a custom validation message component.
 	 */
-	errors: Writable<string[] | undefined>;
+	errors: Writable<{ _errors?: string[] } | string[] | undefined>;
 
 	/**
 	 * A writable store containing the current value of the field.

--- a/src/routes/test/a/+page.svelte
+++ b/src/routes/test/a/+page.svelte
@@ -11,14 +11,23 @@
 		}),
 		bio: z.string().max(250, "Bio must be at most 250 characters").optional(),
 		website: z.string().url("Invalid URL").optional(),
-		usage: z.boolean().default(true)
+		usage: z.boolean().default(true),
+		multiSelect: z.array(z.string()).nonempty()
 	});
+
+	const multiSelectItems = [
+		{ label: "First", value: "first" },
+		{ label: "Second", value: "second" },
+		{ label: "Third", value: "third" },
+		{ label: "Fourth", value: "fourth" }
+	];
 </script>
 
 <script lang="ts">
 	import { Form } from "@/lib/index.js";
 	import type { PageData } from "./$types.js";
 	import { Button } from "@/components/ui/button/index.js";
+	import { Select } from "bits-ui";
 
 	export let data: PageData;
 </script>
@@ -102,6 +111,43 @@
 				<Form.Validation data-testid="usage-validation" class="text-destructive" />
 				<Form.Description data-testid="usage-description">usage description</Form.Description>
 			</div>
+		</Form.Field>
+		<Form.Field {config} name="multiSelect" let:setValue let:value>
+			<Form.Label>Multi-select</Form.Label>
+			<Select.Root
+				items={multiSelectItems}
+				let:ids
+				multiple={true}
+				onSelectedChange={(selected) => {
+					setValue(selected?.map((opt) => opt.value));
+				}}
+			>
+				<Select.Input />
+				<Form.Control let:attrs id={ids.trigger}>
+					<Select.Trigger
+						{...attrs}
+						class="flex h-9 w-full items-center justify-between rounded-md border-0 bg-white px-3 py-1.5 text-gray-900 shadow-sm outline-none ring-1 ring-inset ring-gray-300 transition-opacity placeholder:text-gray-400 hover:opacity-90 focus:ring-2 focus:ring-inset focus:ring-violet-600 sm:text-sm sm:leading-6"
+					>
+						<Select.Value placeholder="Select one or more" class="truncate" />
+						&downarrow;
+					</Select.Trigger>
+					<Select.Content
+						class="z-10 flex max-h-72 select-none flex-col overflow-y-auto rounded-md bg-white shadow outline-none focus:ring-2 focus:ring-violet-700"
+					>
+						{#each multiSelectItems as option}
+							<Select.Item
+								value={option.value}
+								label={option.label}
+								class="flex cursor-pointer select-none items-center justify-between px-4 py-1 text-gray-800 outline-none data-[highlighted]:!bg-violet-900 data-[selected]:bg-violet-100 data-[highlighted]:!text-violet-100 data-[selected]:text-violet-900"
+							>
+								{option.label}
+								<Select.ItemIndicator>&check;</Select.ItemIndicator>
+							</Select.Item>
+						{/each}
+					</Select.Content>
+				</Form.Control>
+			</Select.Root>
+			<Form.Validation class="text-destructive" />
 		</Form.Field>
 		<Button type="submit" data-testid="submit">Submit</Button>
 	</Form.Root>


### PR DESCRIPTION
When needing a custom multi-select input (using something like bits), Form.Validation fails to represent the actual validity of the field because superforms sets the `$errors` store to an object with the following shape `{_errors: string[]}`.

This PR adds handling for either shape and updates types of the form field store to change the errors shape to `Writable<{_errors?: string[]} | string[] | undefined>`. It also adds test UI for repro that can be reverted once satisfied with the changes.