### PR TITLE
Fix: Resolve Zod schema JSON conversion error

### DIFF
--- a/sites/docs/content/quick-start.md
+++ b/sites/docs/content/quick-start.md
@@ -38,7 +38,7 @@ export const schema = z.object({
 	theme: z.enum(themes).default("light"),
 	language: z.enum(languages).default("en"),
 	marketingEmails: z.boolean().default(true),
-	allergies: z.array(z.enum(allergies)),
+	allergies: z.enum(allergies).array().default([]),
 });
 ```
 


### PR DESCRIPTION
## Overview
Fixed a Zod schema JSON conversion error by adding a default empty array to the allergies field in the schema.

## Changes
- Modified `schema.ts` to add `.default([])` to the allergies array field
- Prevents undefined error during schema JSON conversion
- Ensures empty allergies selection is handled correctly

## Testing
- Verified schema conversion no longer throws TypeError
- Confirmed form rendering and validation work as expected