### PR TITLE
feat: `controlProps()` and `labelProps()`

### DIFF
--- a/.changeset/fresh-coats-hunt.md
+++ b/.changeset/fresh-coats-hunt.md
@@ -1,0 +1,5 @@
+---
+"formsnap": minor
+---
+
+feat: add `controlProps()` and `labelProps()` to simplify usage

--- a/docs/src/content/components/control.md
+++ b/docs/src/content/components/control.md
@@ -25,10 +25,27 @@ The `Control` component doesn't render an element itself, it strictly provides c
 ## Usage
 
 ```svelte title="+page.svelte"
+<script lang="ts">
+	import { Control, controlProps } from "formsnap";
+</script>
+
 <Control>
-	{#snippet children({ props })}
-		<input type="text" {...props} bind:value={$formData.name} />
-	{/snippet}
+	<input type="text" {...controlProps()} bind:value={$formData.name} />
+</Control>
+```
+
+## controlProps
+
+The `controlProps` function returns the props for the closest ancestor `Control` component. Use this function to spread the props onto the control element/component.
+
+```svelte
+<script lang="ts">
+	import { Control, controlProps } from "formsnap";
+</script>
+
+<Control>
+	<!-- controlProps() gets the props from the closest <Control> -->
+	<input type="text" {...controlProps()} bind:value={$formData.name} />
 </Control>
 ```
 
@@ -60,7 +77,7 @@ Here's how you might do just that:
 
 ```svelte title="CustomControl.svelte"
 <script lang="ts">
-	import { Control, Label } from "formsnap";
+	import { Control, Label, controlProps } from "formsnap";
 	import type { ComponentProps } from "svelte";
 
 	let {
@@ -75,12 +92,10 @@ Here's how you might do just that:
 </script>
 
 <Control {...restProps}>
-	{#snippet children({ props })}
-		<div class="flex flex-col gap-2">
-			<Label>{label}</Label>
-			<!-- Forward the props to the children snippet -->
-			{@render childrenProp({ props })}
-		</div>
-	{/snippet}
+	<div class="flex flex-col gap-2">
+		<Label>{label}</Label>
+		<!-- Forward the props to the children snippet -->
+		{@render childrenProp({ props: controlProps() })}
+	</div>
 </Control>
 ```

--- a/docs/src/content/components/description.md
+++ b/docs/src/content/components/description.md
@@ -14,13 +14,11 @@ Descriptions must be used within the context of a [Field](/docs/components/field
 
 ## Usage
 
-```svelte {8}
+```svelte {6}
 <Field name="name" {form}>
 	<Control>
-		{#snippet children({ props })}
-			<Label>Name</Label>
-			<input type="text" {...attrs} />
-		{/snippet}
+		<Label>Name</Label>
+		<input type="text" {...controlProps()} />
 	</Control>
 	<Description>Your full name, including your middle name.</Description>
 </Field>

--- a/docs/src/content/components/element-field.md
+++ b/docs/src/content/components/element-field.md
@@ -42,9 +42,7 @@ Here's an example of how you might use the `ElementField` component to create a 
 		{#each $formData.urls as _, i}
 			<ElementField {form} name="urls[{i}]">
 				<Control>
-					{#snippet children({ props })}
-						<input type="url" bind:value={$formData.urls[i]} {...props} />
-					{/snippet}
+					<input type="url" bind:value={$formData.urls[i]} {...controlProps()} />
 				</Control>
 				<FieldErrors />
 			</ElementField>

--- a/docs/src/content/components/fieldset.md
+++ b/docs/src/content/components/fieldset.md
@@ -18,15 +18,13 @@ This component automatically includes the [Field](/docs/components/field) compon
 
 When you have a group of radio buttons related to a single field, you should use a `Fieldset` to group them together.
 
-```svelte {1-2,13}
+```svelte {1-2,11}
 <Fieldset {form} name="theme">
 	<Legend>Select your theme</Legend>
 	{#each themes as theme}
 		<Control>
-			{#snippet children({ props })}
-				<input {...props} type="radio" bind:group={$formData.theme} value={theme} />
-				<Label>{theme}</Label>
-			{/snippet}
+			<input {...controlProps()} type="radio" bind:group={$formData.theme} value={theme} />
+			<Label>{theme}</Label>
 		</Control>
 	{/each}
 	<Description>Help us understand your preferences by selecting a theme.</Description>
@@ -38,20 +36,18 @@ When you have a group of radio buttons related to a single field, you should use
 
 When you have a group of checkboxes related to a single field, typically used for multiple selections, you should use a `Fieldset` to group them together.
 
-```svelte {1-2,18}
+```svelte {1-2,16}
 <Fieldset {form} name="allergies">
 	<Legend>Any food allergies?</Legend>
 	{#each allergies as allergy}
 		<Control>
-			{#snippet children({ props })}
-				<input
-					{...props}
-					type="checkbox"
-					bind:group={$formData.allergies}
-					value={allergy}
-				/>
-				<Label>{allergy}</Label>
-			{/snippet}
+			<input
+				{...controlProps()}
+				type="checkbox"
+				bind:group={$formData.allergies}
+				value={allergy}
+			/>
+			<Label>{allergy}</Label>
 		</Control>
 	{/each}
 	<Description>We'll make sure to accommodate your dietary needs.</Description>

--- a/docs/src/content/components/label.md
+++ b/docs/src/content/components/label.md
@@ -17,10 +17,8 @@ When using a `Label` inside a [Control](/docs/components/control), you don't nee
 ```svelte {3}
 <Field {form} name="name">
 	<Control>
-		{#snippet children({ props })}
-			<Label>Name</Label>
-			<input type="text" {...props} />
-		{/snippet}
+		<Label>Name</Label>
+		<input type="text" {...controlProps()} />
 	</Control>
 </Field>
 ```

--- a/docs/src/content/composition/control-props.md
+++ b/docs/src/content/composition/control-props.md
@@ -1,0 +1,20 @@
+---
+title: controlProps
+description: Retrieves the props from the closest Control component's context.
+section: Composition
+---
+
+Use the `controlProps` function to retrieve a reactive reference to the props from the closest `Control` component's context.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { Label, Control, controlProps } from "formsnap";
+</script>
+
+<Control>
+	<Label>Hello</Label>
+	<input type="text" {...controlProps()} bind:value={$formData.name} />
+</Control>
+```

--- a/docs/src/content/composition/label-props.md
+++ b/docs/src/content/composition/label-props.md
@@ -1,0 +1,20 @@
+---
+title: labelProps
+description: Retrieves the label props from the closest Control component's context.
+section: Composition
+---
+
+Use the `labelProps` function to retrieve a reactive reference to the label props from the closest `Control` component's context. The label props are used to associate the control element with the label.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { Control, controlProps, labelProps } from "formsnap";
+</script>
+
+<Control>
+	<label {...labelProps()}>Hello</label>
+	<input type="text" {...controlProps()} bind:value={$formData.name} />
+</Control>
+```

--- a/docs/src/content/index.md
+++ b/docs/src/content/index.md
@@ -91,7 +91,7 @@ All is not lost though, as the whole idea behind Formsnap is to make this proces
 
 ```svelte title="+page.svelte"
 <script lang="ts">
-	import { Field, Control, Label, FieldErrors, Description } from "formsnap";
+	import { Field, Control, Label, FieldErrors, Description, controlProps } from "formsnap";
 	import { signupFormSchema } from "./schema.ts";
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { superForm } from "sveltekit-superforms";
@@ -106,30 +106,24 @@ All is not lost though, as the whole idea behind Formsnap is to make this proces
 <form method="POST" use:enhance>
 	<Field {form} name="name">
 		<Control>
-			{#snippet children({ props })}
-				<Label>Name</Label>
-				<input {...props} bind:value={$formData.name} />
-			{/snippet}
+			<Label>Name</Label>
+			<input {...controlProps()} bind:value={$formData.name} />
 		</Control>
 		<Description>Be sure to use your real name.</Description>
 		<FieldErrors />
 	</Field>
 	<Field {form} name="email">
 		<Control>
-			{#snippet children({ props })}
-				<Label>Email</Label>
-				<input {...props} type="email" bind:value={$formData.email} />
-			{/snippet}
+			<Label>Email</Label>
+			<input {...controlProps()} type="email" bind:value={$formData.email} />
 		</Control>
 		<Description>It's preferred that you use your company email.</Description>
 		<FieldErrors />
 	</Field>
 	<Field {form} name="password">
 		<Control>
-			{#snippet children({ props })}
-				<Label>Password</Label>
-				<input {...props} type="password" bind:value={$formData.password} />
-			{/snippet}
+			<Label>Password</Label>
+			<input {...controlProps()} type="password" bind:value={$formData.password} />
 		</Control>
 		<Description>Ensure the password is at least 10 characters.</Description>
 		<FieldErrors />

--- a/docs/src/content/quick-start.md
+++ b/docs/src/content/quick-start.md
@@ -136,7 +136,7 @@ Now let's add the remaining parts of the field:
 ```svelte title="src/routes/settings/+page.svelte"
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms";
-	import { Field, Control, Label, Description, FieldErrors } from "formsnap";
+	import { Field, Control, Label, Description, FieldErrors, controlProps } from "formsnap";
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { allergies, schema, themes } from "./schema.js";
 	import SuperDebug from "sveltekit-superforms";
@@ -152,10 +152,8 @@ Now let's add the remaining parts of the field:
 <form method="POST" use:enhance>
 	<Field {form} name="email">
 		<Control>
-			{#snippet children({ props })}
-				<Label>Email</Label>
-				<input {...props} type="email" bind:value={$formData.email} />
-			{/snippet}
+			<Label>Email</Label>
+			<input {...controlProps()} type="email" bind:value={$formData.email} />
 		</Control>
 		<Description>Use your company email if you have one.</Description>
 		<FieldErrors />
@@ -164,7 +162,7 @@ Now let's add the remaining parts of the field:
 <SuperDebug data={$formData} />
 ```
 
-We've first added the [Control](/docs/components/control) component. `Control`s are used to represent a form control and its label. They keep the control and label in sync via the `props` snippet prop, which is spread onto the control. Inside the `Control`, we've added the [Label](/docs/components/label) component, which will automatically associate itself with the control the `props` are spread onto. We've also added the control itself, which is an `input` that we're binding to the `email` property of the form data.
+We've first added the [Control](/docs/components/control) component. `Control`s are used to represent a form control and its label. They keep the control and label in sync via the `controlProps()` function, which is provided by the `Control` component and is spread onto the control element. Inside the `Control`, we've added the [Label](/docs/components/label) component, which will automatically associate itself with the control the `props` are spread onto. We've also added the control itself, which is an `input` that we're binding to the `email` property of the form data.
 
 The [Description](/docs/components/description) component is optional, but it's useful for providing additional context to the user about the field. It'll be synced with the `aria-describedby` attribute on the input, so it's accessible to screen readers.
 
@@ -177,7 +175,16 @@ And that's really all it takes to setup a form field. Let's continue on with the
 ```svelte title="src/routes/settings/+page.svelte"
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms";
-	import { Field, Control, Label, Description, FieldErrors, Fieldset, Legend } from "formsnap";
+	import {
+		Field,
+		Control,
+		Label,
+		Description,
+		FieldErrors,
+		Fieldset,
+		Legend,
+		controlProps,
+	} from "formsnap";
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { allergies, schema, themes } from "./schema.js";
 	import SuperDebug from "sveltekit-superforms";
@@ -193,34 +200,28 @@ And that's really all it takes to setup a form field. Let's continue on with the
 <form use:enhance class="mx-auto flex max-w-md flex-col" method="POST">
 	<Field {form} name="email">
 		<Control>
-			{#snippet children({ props })}
-				<Label>Email</Label>
-				<input {...props} type="email" bind:value={$formData.email} />
-			{/snippet}
+			<Label>Email</Label>
+			<input {...controlProps()} type="email" bind:value={$formData.email} />
 		</Control>
 		<Description>Company email is preferred</Description>
 		<FieldErrors />
 	</Field>
 	<Field {form} name="bio">
 		<Control>
-			{#snippet children({ props })}
-				<Label>Bio</Label>
-				<textarea {...props} bind:value={$formData.bio} />
-			{/snippet}
+			<Label>Bio</Label>
+			<textarea {...controlProps()} bind:value={$formData.bio} />
 		</Control>
 		<Description>Tell us a bit about yourself.</Description>
 		<FieldErrors />
 	</Field>
 	<Field {form} name="language">
 		<Control>
-			{#snippet children({ props })}
-				<Label>Language</Label>
-				<select {...props} bind:value={$formData.language}>
-					<option value="fr">French</option>
-					<option value="es">Spanish</option>
-					<option value="en">English</option>
-				</select>
-			{/snippet}
+			<Label>Language</Label>
+			<select {...controlProps()} bind:value={$formData.language}>
+				<option value="fr">French</option>
+				<option value="es">Spanish</option>
+				<option value="en">English</option>
+			</select>
 		</Control>
 		<Description>Help us address you properly.</Description>
 		<FieldErrors />
@@ -229,10 +230,13 @@ And that's really all it takes to setup a form field. Let's continue on with the
 		<Legend>Select your theme</Legend>
 		{#each themes as theme}
 			<Control>
-				{#snippet children({ props })}
-					<Label>{theme}</Label>
-					<input {...props} type="radio" value={theme} bind:group={$formData.theme} />
-				{/snippet}
+				<Label>{theme}</Label>
+				<input
+					{...controlProps()}
+					type="radio"
+					value={theme}
+					bind:group={$formData.theme}
+				/>
 			</Control>
 		{/each}
 		<Description>We prefer dark mode, but the choice is yours.</Description>
@@ -240,10 +244,8 @@ And that's really all it takes to setup a form field. Let's continue on with the
 	</Fieldset>
 	<Field {form} name="marketingEmails">
 		<Control>
-			{#snippet children({ props })}
-				<input {...props} type="checkbox" bind:checked={$formData.marketingEmails} />
-				<Label>I want to receive marketing emails</Label>
-			{/snippet}
+			<input {...controlProps()} type="checkbox" bind:checked={$formData.marketingEmails} />
+			<Label>I want to receive marketing emails</Label>
 		</Control>
 		<Description>Stay up to date with our latest news and offers.</Description>
 		<FieldErrors />
@@ -252,15 +254,13 @@ And that's really all it takes to setup a form field. Let's continue on with the
 		<Legend>Food allergies</Legend>
 		{#each allergies as allergy}
 			<Control>
-				{#snippet children({ props })}
-					<input
-						{...props}
-						type="checkbox"
-						bind:group={$formData.allergies}
-						value={allergy}
-					/>
-					<Label>{allergy}</Label>
-				{/snippet}
+				<input
+					{...controlProps()}
+					type="checkbox"
+					bind:group={$formData.allergies}
+					value={allergy}
+				/>
+				<Label>{allergy}</Label>
 			</Control>
 		{/each}
 		<Description>When we provide lunch, we'll accommodate your needs.</Description>

--- a/docs/src/content/recipes/bits-ui-select.md
+++ b/docs/src/content/recipes/bits-ui-select.md
@@ -53,7 +53,7 @@ export const schema = z.object({
 	import { superForm } from "sveltekit-superforms";
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { Select } from "bits-ui";
-	import { Field, Control, Label, FieldErrors } from "formsnap";
+	import { Field, Control, Label, FieldErrors, controlProps } from "formsnap";
 	import { schema, languages } from "./schema.js";
 
 	let { data } = $props();
@@ -72,21 +72,19 @@ export const schema = z.object({
 <form method="POST" use:enhance>
 	<Field {form} name="language">
 		<Control>
-			{#snippet children({ props })}
-				<Label>Language</Label>
-				<Select.Root type="single" bind:value={$formData.language} name={props.name}>
-					<Select.Trigger {...props}>
-						{selectedLabel}
-					</Select.Trigger>
-					<Select.Content>
-						{#each Object.entries(languages) as [value, label]}
-							<Select.Item {value}>
-								{label}
-							</Select.Item>
-						{/each}
-					</Select.Content>
-				</Select.Root>
-			{/snippet}
+			<Label>Language</Label>
+			<Select.Root type="single" bind:value={$formData.language} name={controlProps().name}>
+				<Select.Trigger {...controlProps()}>
+					{selectedLabel}
+				</Select.Trigger>
+				<Select.Content>
+					{#each Object.entries(languages) as [value, label]}
+						<Select.Item {value}>
+							{label}
+						</Select.Item>
+					{/each}
+				</Select.Content>
+			</Select.Root>
 		</Control>
 		<Description>The docs will be translated to your preferred language.</Description>
 		<FieldErrors />
@@ -146,7 +144,7 @@ export const schema = z.object({
 	import { superForm } from "sveltekit-superforms";
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { Select } from "bits-ui";
-	import { Field, Control, Label, FieldErrors } from "formsnap";
+	import { Field, Control, Label, FieldErrors, controlProps } from "formsnap";
 	import { schema, colors } from "./schema.js";
 
 	let { data } = $props();
@@ -165,19 +163,17 @@ export const schema = z.object({
 <form method="POST" use:form.enhance>
 	<Field {form} name="colors">
 		<Control>
-			{#snippet children({ props })}
-				<Label>Favorite colors</Label>
-				<Select.Root type="multiple" bind:value={$formData.colors} name={props.name}>
-					<Select.Trigger {...props}>
-						{selectedColors}
-					</Select.Trigger>
-					<Select.Content>
-						{#each Object.entries(colors) as [value, label]}
-							<Select.Item {value} {label} />
-						{/each}
-					</Select.Content>
-				</Select.Root>
-			{/snippet}
+			<Label>Favorite colors</Label>
+			<Select.Root type="multiple" bind:value={$formData.colors} name={controlProps().name}>
+				<Select.Trigger {...controlProps()}>
+					{selectedColors}
+				</Select.Trigger>
+				<Select.Content>
+					{#each Object.entries(colors) as [value, label]}
+						<Select.Item {value} {label} />
+					{/each}
+				</Select.Content>
+			</Select.Root>
 		</Control>
 		<Description>We'll use these colors to customize your experience.</Description>
 		<FieldErrors />

--- a/docs/src/content/recipes/checkbox-groups.md
+++ b/docs/src/content/recipes/checkbox-groups.md
@@ -105,7 +105,15 @@ We'll first import the components we'll need from Formsnap, and then setup a `fo
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms";
 	import { zodClient } from "sveltekit-superforms/adapters";
-	import { Fieldset, Legend, Label, Control, FieldErrors, Description } from "formsnap";
+	import {
+		Fieldset,
+		Legend,
+		Label,
+		Control,
+		FieldErrors,
+		Description,
+		controlProps,
+	} from "formsnap";
 
 	let { data } = $props();
 
@@ -147,15 +155,13 @@ Next, we'll iterate over the `allergies` array and create a [Control](/docs/comp
 		<Legend>Select your allergies</Legend>
 		{#each allergies as allergy}
 			<Control>
-				{#snippet children({ props })}
-					<input
-						type="checkbox"
-						{...props}
-						bind:group={$formData.allergies}
-						value={allergy}
-					/>
-					<Label>{value}</Label>
-				{/snippet}
+				<input
+					type="checkbox"
+					{...controlProps()}
+					bind:group={$formData.allergies}
+					value={allergy}
+				/>
+				<Label>{value}</Label>
 			</Control>
 		{/each}
 		<Description>We'll accommodate your dietary restrictions.</Description>
@@ -249,7 +255,15 @@ export const actions: Actions = {
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms";
 	import { zodClient } from "sveltekit-superforms/adapters";
-	import { Fieldset, Legend, Label, Control, FieldErrors, Description } from "formsnap";
+	import {
+		Fieldset,
+		Legend,
+		Label,
+		Control,
+		FieldErrors,
+		Description,
+		controlProps,
+	} from "formsnap";
 
 	let { data } = $props();
 
@@ -264,15 +278,13 @@ export const actions: Actions = {
 		<Legend>Select any allergies you may have</Legend>
 		{#each allergies as allergy}
 			<Control>
-				{#snippet children({ props })}
-					<input
-						type="checkbox"
-						{...props}
-						bind:group={$formData.allergies}
-						value={allergy}
-					/>
-					<Label>{allergy}</Label>
-				{/snippet}
+				<input
+					type="checkbox"
+					{...controlProps()}
+					bind:group={$formData.allergies}
+					value={allergy}
+				/>
+				<Label>{allergy}</Label>
 			</Control>
 		{/each}
 		<Description>We'll accommodate your dietary restrictions.</Description>

--- a/docs/src/content/recipes/checkbox-groups.md
+++ b/docs/src/content/recipes/checkbox-groups.md
@@ -100,7 +100,7 @@ Now that our SuperForm is initialized, we can use it to construct our checkbox g
 
 We'll first import the components we'll need from Formsnap, and then setup a `form` element with the `enhance` action to progressively enhance the form with client-side validation.
 
-```svelte title="+page.svelte" {5,15-18}
+```svelte title="+page.svelte" {5-13,15-19}
 <!-- script context="module" tag  -->
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms";
@@ -148,7 +148,7 @@ Since each checkbox in the group is related to a single field, we'll use a `Fiel
 
 Next, we'll iterate over the `allergies` array and create a [Control](/docs/components/control) that includes a [Label](/docs/components/label) and a checkbox input for each option.
 
-```svelte {5-17}
+```svelte {5-15}
 <!-- script tags -->
 <form method="POST" use:form.enhance>
 	<Fieldset {form} name="allergies">

--- a/docs/src/content/recipes/dynamic-fields.md
+++ b/docs/src/content/recipes/dynamic-fields.md
@@ -120,7 +120,7 @@ The [Description](/docs/components/description) component will provide additiona
 
 Now that we've scaffolded the `Fieldset`, we can iterate over the `$formData.urls` array to render the individual URL fields, which are represented by the [ElementField](/docs/components/element-field) component.
 
-```svelte title="+page.svelte" {5-18}
+```svelte title="+page.svelte" {5-16}
 <!-- script tag -->
 <form use:enhance method="POST">
 	<Fieldset {form} name="urls">
@@ -155,7 +155,7 @@ You should always include a label for each input for accessibility purposes. In 
 
 At the moment, the user can only have two URLs in their profile. We want to allow them to add and remove URLs as needed. We can achieve this by adding buttons to add and remove URLs.
 
-```svelte showLineNumbers title="+page.svelte" {23-29,41-43,53}
+```svelte showLineNumbers title="+page.svelte" {24-30,41,53}
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms";
 	import { zodClient } from "sveltekit-superforms/adapters";

--- a/docs/src/content/recipes/dynamic-fields.md
+++ b/docs/src/content/recipes/dynamic-fields.md
@@ -76,6 +76,7 @@ We have a few components we need to import to build the form.
 		Label,
 		FieldErrors,
 		Description,
+		controlProps,
 	} from "formsnap";
 	import { schema } from "./schema.js";
 
@@ -127,10 +128,8 @@ Now that we've scaffolded the `Fieldset`, we can iterate over the `$formData.url
 		{#each $formData.urls as _, i}
 			<ElementField {form} name="urls[{i}]">
 				<Control>
-					{#snippet children({ props })}
-						<Label class="sr-only">URL {i + 1}</Label>
-						<input type="url" {...props} bind:value={$formData.urls[i]} />
-					{/snippet}
+					<Label class="sr-only">URL {i + 1}</Label>
+					<input type="url" {...controlProps()} bind:value={$formData.urls[i]} />
 				</Control>
 				<Description class="sr-only">
 					This URL will be publicly available on your profile.
@@ -168,6 +167,7 @@ At the moment, the user can only have two URLs in their profile. We want to allo
 		Label,
 		FieldErrors,
 		Description,
+		controlProps,
 	} from "formsnap";
 	import { schema } from "./schema.js";
 
@@ -194,13 +194,9 @@ At the moment, the user can only have two URLs in their profile. We want to allo
 		{#each $formData.urls as _, i}
 			<ElementField {form} name="urls[{i}]">
 				<Control>
-					{#snippet children({ props })}
-						<Label class="sr-only">URL {i + 1}</Label>
-						<input type="url" {...props} bind:value={$formData.urls[i]} />
-						<button type="button" onclick={() => removeUrlByIndex(i)}>
-							Remove URL
-						</button>
-					{/snippet}
+					<Label class="sr-only">URL {i + 1}</Label>
+					<input type="url" {...controlProps()} bind:value={$formData.urls[i]} />
+					<button type="button" onclick={() => removeUrlByIndex(i)}> Remove URL </button>
 				</Control>
 				<Description class="sr-only">
 					This URL will be publicly available on your profile.
@@ -257,6 +253,7 @@ export const schema = z.object({
 		Label,
 		FieldErrors,
 		Description,
+		controlProps,
 	} from "formsnap";
 	import { schema } from "./schema.js";
 
@@ -283,13 +280,9 @@ export const schema = z.object({
 		{#each $formData.urls as _, i}
 			<ElementField {form} name="urls[{i}]">
 				<Control>
-					{#snippet children({ props })}
-						<Label class="sr-only">URL {i + 1}</Label>
-						<input type="url" {...props} bind:value={$formData.urls[i]} />
-						<button type="button" onclick={() => removeUrlByIndex(i)}>
-							Remove URL
-						</button>
-					{/snippet}
+					<Label class="sr-only">URL {i + 1}</Label>
+					<input type="url" {...controlProps()} bind:value={$formData.urls[i]} />
+					<button type="button" onclick={() => removeUrlByIndex(i)}> Remove URL </button>
 				</Control>
 				<Description class="sr-only">
 					This URL will be publicly available on your profile.

--- a/docs/src/content/recipes/multiple-select.md
+++ b/docs/src/content/recipes/multiple-select.md
@@ -74,7 +74,7 @@ At a minimum we need to import the [Field](/docs/components/field), [Control](/d
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms";
 	import { zodClient } from "sveltekit-superforms/adapters";
-	import { Field, Control, Label, FieldErrors } from "formsnap";
+	import { Field, Control, Label, FieldErrors, controlProps } from "formsnap";
 	import { schema } from "./schema.js";
 
 	let { data } = $props();
@@ -101,18 +101,16 @@ The first field we'll create is the `scoops` field, which will be a regular sele
 <form use:form.enhance method="POST">
 	<Field {form} name="scoops">
 		<Control>
-			{#snippet children({ props })}
-				<div class="flex flex-col items-start gap-1">
-					<Label>Number of scoops</Label>
-					<select {...props} bind:value={$formData.scoops}>
-						{#each Array.from({ length: 5 }, (_, i) => i + 1) as num}
-							<option value={num}>
-								{num === 1 ? `${num} Scoop` : `${num} Scoops`}
-							</option>
-						{/each}
-					</select>
-				</div>
-			{/snippet}
+			<div class="flex flex-col items-start gap-1">
+				<Label>Number of scoops</Label>
+				<select {...controlProps()} bind:value={$formData.scoops}>
+					{#each Array.from({ length: 5 }, (_, i) => i + 1) as num}
+						<option value={num}>
+							{num === 1 ? `${num} Scoop` : `${num} Scoops`}
+						</option>
+					{/each}
+				</select>
+			</div>
 		</Control>
 		<FieldErrors />
 	</Field>
@@ -129,35 +127,31 @@ Next, let's create the `flavors` field. This field will be a multiple select inp
 <form use:form.enhance method="POST">
 	<Field {form} name="scoops">
 		<Control>
-			{#snippet children({ props })}
-				<div class="flex flex-col items-start gap-1">
-					<Label>Number of scoops</Label>
-					<select {...props} bind:value={$formData.scoops}>
-						{#each Array.from({ length: 5 }, (_, i) => i + 1) as num}
-							<option value={num}>
-								{num === 1 ? `${num} Scoop` : `${num} Scoops`}
-							</option>
-						{/each}
-					</select>
-				</div>
-			{/snippet}
+			<div class="flex flex-col items-start gap-1">
+				<Label>Number of scoops</Label>
+				<select {...controlProps()} bind:value={$formData.scoops}>
+					{#each Array.from({ length: 5 }, (_, i) => i + 1) as num}
+						<option value={num}>
+							{num === 1 ? `${num} Scoop` : `${num} Scoops`}
+						</option>
+					{/each}
+				</select>
+			</div>
 		</Control>
 		<FieldErrors />
 	</Field>
 	<Field {form} name="flavors">
 		<Control>
-			{#snippet children({ props })}
-				<div class="flex flex-col items-start gap-1">
-					<Label>What flavors do you fancy?</Label>
-					<select multiple bind:value={$formData.flavors} {...props}>
-						{#each flavors as flavor}
-							<option value={flavor} selected={$formData.flavors.includes(flavor)}>
-								{flavor}
-							</option>
-						{/each}
-					</select>
-				</div>
-			{/snippet}
+			<div class="flex flex-col items-start gap-1">
+				<Label>What flavors do you fancy?</Label>
+				<select multiple bind:value={$formData.flavors} {...controlProps()}>
+					{#each flavors as flavor}
+						<option value={flavor} selected={$formData.flavors.includes(flavor)}>
+							{flavor}
+						</option>
+					{/each}
+				</select>
+			</div>
 		</Control>
 		<FieldErrors />
 	</Field>
@@ -176,52 +170,46 @@ Finally, let's create the `toppings` field. This field will also be a multiple s
 <form use:form.enhance method="POST">
 	<Field {form} name="scoops">
 		<Control>
-			{#snippet children({ props })}
-				<div class="flex flex-col items-start gap-1">
-					<Label>Number of scoops</Label>
-					<select {...props} bind:value={$formData.scoops}>
-						{#each Array.from({ length: 5 }, (_, i) => i + 1) as num}
-							<option value={num}>
-								{num === 1 ? `${num} Scoop` : `${num} Scoops`}
-							</option>
-						{/each}
-					</select>
-				</div>
-			{/snippet}
+			<div class="flex flex-col items-start gap-1">
+				<Label>Number of scoops</Label>
+				<select {...controlProps()} bind:value={$formData.scoops}>
+					{#each Array.from({ length: 5 }, (_, i) => i + 1) as num}
+						<option value={num}>
+							{num === 1 ? `${num} Scoop` : `${num} Scoops`}
+						</option>
+					{/each}
+				</select>
+			</div>
 		</Control>
 		<FieldErrors />
 	</Field>
 	<Field {form} name="flavors">
 		<Control>
-			{#snippet children({ props })}
-				<div class="flex flex-col items-start gap-1">
-					<Label>What flavors do you fancy?</Label>
-					<select multiple bind:value={$formData.flavors} {...props}>
-						{#each flavors as flavor}
-							<option value={flavor} selected={$formData.flavors.includes(flavor)}>
-								{flavor}
-							</option>
-						{/each}
-					</select>
-				</div>
-			{/snippet}
+			<div class="flex flex-col items-start gap-1">
+				<Label>What flavors do you fancy?</Label>
+				<select multiple bind:value={$formData.flavors} {...controlProps()}>
+					{#each flavors as flavor}
+						<option value={flavor} selected={$formData.flavors.includes(flavor)}>
+							{flavor}
+						</option>
+					{/each}
+				</select>
+			</div>
 		</Control>
 		<FieldErrors />
 	</Field>
 	<Field {form} name="toppings">
 		<Control>
-			{#snippet children({ props })}
-				<div class="flex flex-col items-start gap-1">
-					<Label>Select your toppings</Label>
-					<select multiple bind:value={$formData.toppings} {...props}>
-						{#each toppings as topping}
-							<option value={topping} selected={$formData.toppings.includes(topping)}>
-								{topping}
-							</option>
-						{/each}
-					</select>
-				</div>
-			{/snippet}
+			<div class="flex flex-col items-start gap-1">
+				<Label>Select your toppings</Label>
+				<select multiple bind:value={$formData.toppings} {...controlProps()}>
+					{#each toppings as topping}
+						<option value={topping} selected={$formData.toppings.includes(topping)}>
+							{topping}
+						</option>
+					{/each}
+				</select>
+			</div>
 		</Control>
 		<FieldErrors />
 	</Field>

--- a/docs/src/content/v2-migration-guide.md
+++ b/docs/src/content/v2-migration-guide.md
@@ -123,6 +123,10 @@ The `Control` component now uses snippet props for attribute passing.
 The `Control` component in v1 simply expose an `attrs` slot prop that was spread onto the control element, like so:
 
 ```svelte title="Formsnap v1 (old)"
+<script lang="ts">
+	import { Control } from "formsnap";
+</script>
+
 <Control let:attrs>
 	<input type="text" {...attrs} bind:value={$formData.name} />
 </Control>
@@ -130,9 +134,21 @@ The `Control` component in v1 simply expose an `attrs` slot prop that was spread
 
 #### After (v2)
 
-In v2, the `Control` component now provides those attributes via a `children` snippet prop, like so:
+In v2, the `Control` component now provides those attributes via the `controlProps` function which retrieves the props from the closest `Control` component's context.
 
 ```svelte title="Formsnap v2 (new)"
+<script lang="ts">
+	import { Control, controlProps } from "formsnap";
+</script>
+
+<Control>
+	<input type="text" {...controlProps()} bind:value={$formData.name} />
+</Control>
+```
+
+Alternatively, you can access the props via the `Control` component's `children` snippet props.
+
+```svelte title="Formsnap v2 (new - alt)"
 <Control>
 	{#snippet children({ props })}
 		<input type="text" {...props} bind:value={$formData.name} />

--- a/docs/src/lib/components/examples/bits-ui-multi-select.svelte
+++ b/docs/src/lib/components/examples/bits-ui-multi-select.svelte
@@ -24,7 +24,7 @@
 	import { defaults, superForm } from "sveltekit-superforms";
 	import { zod, zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
-	import { Field, Control, Description, FieldErrors, Label } from "formsnap";
+	import { Field, Control, Description, FieldErrors, Label, controlProps } from "formsnap";
 	import { DemoContainer, Button, Select } from "@svecodocs/kit";
 
 	const form = superForm(defaults(zod(schema)), {
@@ -48,19 +48,21 @@
 	<form method="POST" action="?/bitsMultiSelect" use:form.enhance class="flex flex-col gap-4">
 		<Field {form} name="colors">
 			<Control>
-				{#snippet children({ props })}
-					<Label>Favorite colors</Label>
-					<Select.Root type="multiple" bind:value={$formData.colors} name={props.name}>
-						<Select.Trigger type="button" {...props} class="w-[180px]">
-							{selectedColors}
-						</Select.Trigger>
-						<Select.Content>
-							{#each Object.entries(colors) as [value, label]}
-								<Select.Item {value} {label} />
-							{/each}
-						</Select.Content>
-					</Select.Root>
-				{/snippet}
+				<Label>Favorite colors</Label>
+				<Select.Root
+					type="multiple"
+					bind:value={$formData.colors}
+					name={controlProps().name}
+				>
+					<Select.Trigger type="button" {...controlProps()} class="w-[180px]">
+						{selectedColors}
+					</Select.Trigger>
+					<Select.Content>
+						{#each Object.entries(colors) as [value, label]}
+							<Select.Item {value} {label} />
+						{/each}
+					</Select.Content>
+				</Select.Root>
 			</Control>
 			<Description>We'll use these colors to customize your experience.</Description>
 			<FieldErrors />

--- a/docs/src/lib/components/examples/bits-ui-select.svelte
+++ b/docs/src/lib/components/examples/bits-ui-select.svelte
@@ -26,7 +26,7 @@
 	import { zod, zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { Button, DemoContainer, Select } from "@svecodocs/kit";
-	import { Field, Control, Description, FieldErrors, Label } from "formsnap";
+	import { Field, Control, Description, FieldErrors, Label, controlProps } from "formsnap";
 
 	const form = superForm(defaults(zod(schema)), {
 		validators: zodClient(schema),
@@ -49,25 +49,25 @@
 	<form method="POST" action="?/bitsSelect" use:enhance class="flex flex-col gap-4">
 		<Field {form} name="language">
 			<Control>
-				{#snippet children({ props })}
-					<Label>Language</Label>
-					<Select.Root type="single" bind:value={$formData.language} name={props.name}>
-						<Select.Trigger {...props} class="w-[180px]">
-							{selectedLabel}
-						</Select.Trigger>
-						<Select.Content>
-							{#each Object.entries(languages) as [value, label]}
-								<Select.Item {value}>
-									{label}
-								</Select.Item>
-							{/each}
-						</Select.Content>
-					</Select.Root>
-					<Description>
-						The docs will be translated to your preferred language.
-					</Description>
-					<FieldErrors />
-				{/snippet}
+				<Label>Language</Label>
+				<Select.Root
+					type="single"
+					bind:value={$formData.language}
+					name={controlProps().name}
+				>
+					<Select.Trigger {...controlProps()} class="w-[180px]">
+						{selectedLabel}
+					</Select.Trigger>
+					<Select.Content>
+						{#each Object.entries(languages) as [value, label]}
+							<Select.Item {value}>
+								{label}
+							</Select.Item>
+						{/each}
+					</Select.Content>
+				</Select.Root>
+				<Description>The docs will be translated to your preferred language.</Description>
+				<FieldErrors />
 			</Control>
 		</Field>
 		<Button class="self-start" type="submit">Submit</Button>

--- a/docs/src/lib/components/examples/checkbox-group.svelte
+++ b/docs/src/lib/components/examples/checkbox-group.svelte
@@ -18,7 +18,15 @@
 <script lang="ts">
 	import { defaults, superForm } from "sveltekit-superforms";
 	import { zod, zodClient } from "sveltekit-superforms/adapters";
-	import { Control, Description, FieldErrors, Fieldset, Label, Legend } from "formsnap";
+	import {
+		Control,
+		controlProps,
+		Description,
+		FieldErrors,
+		Fieldset,
+		Label,
+		Legend,
+	} from "formsnap";
 	import { toast } from "svelte-sonner";
 	import { Button, DemoContainer } from "@svecodocs/kit";
 
@@ -45,16 +53,14 @@
 				{#each allergies as allergy}
 					<div class="flex items-center gap-3">
 						<Control>
-							{#snippet children({ props })}
-								<input
-									class="accent-brand"
-									type="checkbox"
-									{...props}
-									bind:group={$formData.allergies}
-									value={allergy}
-								/>
-								<Label>{allergy}</Label>
-							{/snippet}
+							<input
+								class="accent-brand"
+								type="checkbox"
+								{...controlProps()}
+								bind:group={$formData.allergies}
+								value={allergy}
+							/>
+							<Label>{allergy}</Label>
 						</Control>
 					</div>
 				{/each}

--- a/docs/src/lib/components/examples/dynamic-fields.svelte
+++ b/docs/src/lib/components/examples/dynamic-fields.svelte
@@ -15,7 +15,15 @@
 	import { defaults, superForm } from "sveltekit-superforms";
 	import { zod, zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
-	import { Fieldset, ElementField, Control, Description, FieldErrors, Legend } from "formsnap";
+	import {
+		Fieldset,
+		ElementField,
+		Control,
+		Description,
+		FieldErrors,
+		Legend,
+		controlProps,
+	} from "formsnap";
 	import { Input, Button, DemoContainer } from "@svecodocs/kit";
 	import Plus from "phosphor-svelte/lib/Plus";
 	import Trash from "phosphor-svelte/lib/Trash";
@@ -55,24 +63,22 @@
 				{#each $formData.urls as _, i}
 					<ElementField {form} name="urls[{i}]">
 						<Control>
-							{#snippet children({ props })}
-								<div class="flex items-center gap-3">
-									<Input
-										type="url"
-										bind:value={$formData.urls[i]}
-										{...props}
-										class="w-full"
-									/>
-									<Button
-										onclick={() => removeUrlByIndex(i)}
-										variant="destructive"
-										size="icon"
-										aria-label="Delete URL {i}"
-									>
-										<Trash />
-									</Button>
-								</div>
-							{/snippet}
+							<div class="flex items-center gap-3">
+								<Input
+									type="url"
+									bind:value={$formData.urls[i]}
+									{...controlProps()}
+									class="w-full"
+								/>
+								<Button
+									onclick={() => removeUrlByIndex(i)}
+									variant="destructive"
+									size="icon"
+									aria-label="Delete URL {i}"
+								>
+									<Trash />
+								</Button>
+							</div>
 						</Control>
 						<Description class="sr-only">
 							This URL will be displayed on your public profile.

--- a/docs/src/lib/components/examples/multiple-select.svelte
+++ b/docs/src/lib/components/examples/multiple-select.svelte
@@ -22,7 +22,7 @@
 <script lang="ts">
 	import { defaults, superForm } from "sveltekit-superforms";
 	import { zod, zodClient } from "sveltekit-superforms/adapters";
-	import { Control, Field, FieldErrors, Label, Description } from "formsnap";
+	import { Control, Field, FieldErrors, Label, Description, controlProps } from "formsnap";
 	import { toast } from "svelte-sonner";
 	import { DemoContainer, Button, NativeSelect } from "@svecodocs/kit";
 
@@ -43,41 +43,35 @@
 	<form method="POST" action="?/multipleSelect" use:form.enhance class="flex flex-col gap-3">
 		<Field {form} name="scoops">
 			<Control>
-				{#snippet children({ props })}
-					<div class="flex flex-col items-start gap-1.5">
-						<Label>Number of scoops</Label>
-						<NativeSelect {...props} bind:value={$formData.scoops}>
-							{#each Array.from({ length: 5 }, (_, i) => i + 1) as num}
-								<option value={num}>{num} {num === 1 ? "Scoop" : "Scoops"} </option>
-							{/each}
-						</NativeSelect>
-					</div>
-				{/snippet}
+				<div class="flex flex-col items-start gap-1.5">
+					<Label>Number of scoops</Label>
+					<NativeSelect {...controlProps()} bind:value={$formData.scoops}>
+						{#each Array.from({ length: 5 }, (_, i) => i + 1) as num}
+							<option value={num}>{num} {num === 1 ? "Scoop" : "Scoops"} </option>
+						{/each}
+					</NativeSelect>
+				</div>
 			</Control>
 			<FieldErrors class="text-destructive dark:text-red-400" />
 		</Field>
 		<Field {form} name="flavors">
 			<div class="flex flex-col gap-1">
 				<Control>
-					{#snippet children({ props })}
-						<div class="flex flex-col items-start gap-1.5">
-							<Label>Select your flavors</Label>
-							<select
-								multiple
-								bind:value={$formData.flavors}
-								{...props}
-								class="w-[200px]"
-							>
-								{#each flavors as flavor}
-									<option
-										value={flavor}
-										selected={$formData.flavors.includes(flavor)}
-										>{flavor}</option
-									>
-								{/each}
-							</select>
-						</div>
-					{/snippet}
+					<div class="flex flex-col items-start gap-1.5">
+						<Label>Select your flavors</Label>
+						<select
+							multiple
+							bind:value={$formData.flavors}
+							{...controlProps()}
+							class="w-[200px]"
+						>
+							{#each flavors as flavor}
+								<option value={flavor} selected={$formData.flavors.includes(flavor)}
+									>{flavor}</option
+								>
+							{/each}
+						</select>
+					</div>
 				</Control>
 				<Description>Only select one flavor per scoop.</Description>
 				<FieldErrors class="text-destructive dark:text-red-400" />
@@ -85,25 +79,21 @@
 		</Field>
 		<Field {form} name="toppings">
 			<Control>
-				{#snippet children({ props })}
-					<div class="flex flex-col items-start gap-1.5">
-						<Label>Select your toppings</Label>
-						<select
-							multiple
-							bind:value={$formData.toppings}
-							{...props}
-							class="w-[200px]"
-						>
-							{#each toppings as topping}
-								<option
-									value={topping}
-									selected={$formData.toppings.includes(topping)}
-									>{topping}</option
-								>
-							{/each}
-						</select>
-					</div>
-				{/snippet}
+				<div class="flex flex-col items-start gap-1.5">
+					<Label>Select your toppings</Label>
+					<select
+						multiple
+						bind:value={$formData.toppings}
+						{...controlProps()}
+						class="w-[200px]"
+					>
+						{#each toppings as topping}
+							<option value={topping} selected={$formData.toppings.includes(topping)}
+								>{topping}</option
+							>
+						{/each}
+					</select>
+				</div>
 			</Control>
 			<FieldErrors class="text-destructive dark:text-red-400" />
 		</Field>

--- a/docs/src/lib/components/logos/blueprint.svelte
+++ b/docs/src/lib/components/logos/blueprint.svelte
@@ -1,0 +1,10 @@
+<script lang="ts" module>
+	// prettier-ignore
+	export { a, blockquote, code, h1, h2, h3, h4, h5, h6, hr, img, li, ol, p, pre, table, td, th, tr, ul } from '@svecodocs/kit'
+</script>
+
+<script lang="ts">
+	let { children } = $props();
+</script>
+
+{@render children?.()}

--- a/packages/formsnap/src/lib/formsnap.svelte.ts
+++ b/packages/formsnap/src/lib/formsnap.svelte.ts
@@ -9,7 +9,7 @@ import {
 import { fromStore } from "svelte/store";
 import type { FormPath, InputConstraint, InputConstraints } from "sveltekit-superforms";
 import type { FormPathArrays, TaintedFields, ValidationErrors } from "sveltekit-superforms/client";
-import { getContext, setContext } from "svelte";
+import { getContext, hasContext, setContext } from "svelte";
 import { extractErrorArray } from "./internal/utils/errors.js";
 import { getValueAtPath } from "./internal/utils/path.js";
 import {
@@ -544,6 +544,11 @@ export function useFormControl(props: UseFormControlProps = {}) {
  * @returns The props to spread onto the element acting as the form control.
  */
 export function controlProps() {
+	if (!hasContext(FORM_CONTROL_CTX)) {
+		throw new Error(
+			"No parent <Control> component found. `controlProps` must be used within a descendant of the <Control> component."
+		);
+	}
 	return useFormControl().props;
 }
 
@@ -562,6 +567,12 @@ export function controlProps() {
  * @returns The props to spread onto the element acting as the form control.
  */
 export function labelProps() {
+	if (!hasContext(FORM_CONTROL_CTX)) {
+		throw new Error(
+			"No parent <Control> component found. `labelProps` must be used within a descendant of the <Control> component."
+		);
+	}
+
 	return useFormControl().labelProps;
 }
 

--- a/packages/formsnap/src/lib/formsnap.svelte.ts
+++ b/packages/formsnap/src/lib/formsnap.svelte.ts
@@ -505,7 +505,7 @@ export type UseFormControlProps = {
 	id?: Getter<string | undefined | null>;
 };
 
-export function useFormControl(props: UseFormControlProps) {
+export function useFormControl(props: UseFormControlProps = {}) {
 	const controlState = getContext<ControlState>(FORM_CONTROL_CTX);
 	const id = $derived(props.id ? props.id() : undefined);
 
@@ -529,6 +529,40 @@ export function useFormControl(props: UseFormControlProps) {
 			return controlState.props;
 		},
 	};
+}
+
+/**
+ * Convenience function to get the props from the closest `Control` component.
+ *
+ * @example
+ * ```svelte
+ * <Control>
+ * 	<!-- Receives props from this ^ Control -->
+ * 	<input {...controlProps()} />
+ * </Control>
+ *```
+ * @returns The props to spread onto the element acting as the form control.
+ */
+export function controlProps() {
+	return useFormControl().props;
+}
+
+/**
+ * Convenience function to get the label props from the closest `Control` component
+ * that will link the label to the associated form control.
+ *
+ * @example
+ * ```svelte
+ * <Control>
+ * 	<!-- Receives label props from this ^ Control -->
+ *  <label {...labelProps()} />
+ * 	<input {...controlProps()} />
+ * </Control>
+ *```
+ * @returns The props to spread onto the element acting as the form control.
+ */
+export function labelProps() {
+	return useFormControl().labelProps;
 }
 
 /**

--- a/packages/formsnap/src/lib/index.ts
+++ b/packages/formsnap/src/lib/index.ts
@@ -2,7 +2,14 @@ import type { SuperForm } from "sveltekit-superforms";
 
 export type { SuperForm as _SuperForm };
 
-export { useFormField, useFormControl, getFormField, getFormControl } from "./formsnap.svelte.js";
+export {
+	useFormField,
+	useFormControl,
+	getFormField,
+	getFormControl,
+	controlProps,
+	labelProps,
+} from "./formsnap.svelte.js";
 export type { UseFormFieldProps, UseFormControlProps } from "./formsnap.svelte.js";
 
 export type * from "./attrs.types.js";


### PR DESCRIPTION
This PR introduces two new functions to Formsnap, `controlProps` and `labelProps`, which will retrieve a reactive reference to the control/label props from the context provided by the closest `<Control>` component in the tree.

These functions reduce the amount of boilerplate required for the `Control` with Formsnap v2.

### Before:

This is still an acceptable way of handling this in Formsnap v2 if you prefer. 

```svelte
<script lang="ts">
	import { Control, Label } from 'formsnap';
</script>


<Control>
	{#snippet children({ props })}
		<Label>Name</Label>
		<input {...props} bind:value={$formData.name} />
	{/snippet}
</Control>
```

### After:
```svelte
<script lang="ts">
	import { Control, Label, controlProps } from 'formsnap'
</script>

<Control>
	<Label>Name</Label>
	<input {...controlProps()} bind:value={$formData.name} />
</Control>
```

or

```svelte
<script lang="ts">
	import { Control, labelProps, controlProps } from 'formsnap';
</script>

<Control>
	<label {...labelProps()}>Name</label>
	<input {...controlProps()} bind:value={$formData.name} />
</Control>
```

